### PR TITLE
fix: switch data change detection algorithm to use newer method

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -52,6 +52,19 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         _LOGGER.debug("Parsing inkbird BLE advertisement data: %s", service_info)
         if not (manufacturer_data := service_info.manufacturer_data):
             return
+        local_name = service_info.name
+        lower_name = local_name.lower()
+        address = service_info.address
+        last_id = list(manufacturer_data)[-1]
+        data = int(last_id).to_bytes(2, byteorder="little") + manufacturer_data[last_id]
+        msg_length = len(data)
+        if (device_type := INKBIRD_NAMES.get(lower_name)) and (
+            msg_length == 9
+            or "0000fff0-0000-1000-8000-00805f9b34fb" in service_info.service_uuids
+        ):
+            self.set_device_name(f"{device_type} {short_address(address)}")
+            self.set_device_type(device_type)
+
         excludes = MANUFACTURER_DATA_ID_EXCLUDES if len(manufacturer_data) > 1 else None
         changed_manufacturer_data = self.changed_manufacturer_data(
             service_info, excludes
@@ -67,10 +80,6 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             + changed_manufacturer_data[last_id]
         )
         msg_length = len(data)
-        local_name = service_info.name
-        lower_name = local_name.lower()
-        address = service_info.address
-
         if (device_type := INKBIRD_NAMES.get(lower_name)) and msg_length == 9:
             self.set_device_name(f"{device_type} {short_address(address)}")
             self.set_device_type(device_type)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -116,6 +116,22 @@ def test_unknown_sps():
     assert parser.supported(service_info) is True
 
 
+def test_sps_variant():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="sps",
+        manufacturer_data={
+            2083: b"\x12\x01q\x08d\x06",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:21:09:09:65:49",
+        rssi=-96,
+        service_data={},
+        source="local",
+    )
+    assert parser.supported(service_info) is True
+
+
 def test_sps_th2_dupe_updates():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,6 +15,20 @@ def test_can_create():
     INKBIRDBluetoothDeviceData()
 
 
+def test_unsupported():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="x",
+        manufacturer_data={},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    parser.supported(service_info) is False
+
+
 def test_sps():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(
@@ -373,6 +387,7 @@ def test_xbbq_2a_adv2():
         source="local",
     )
     assert parser.supported(service_info) is True
+    parser = INKBIRDBluetoothDeviceData()
     result = parser.update(service_info)
     assert result == SensorUpdate(
         title=None,
@@ -386,21 +401,42 @@ def test_xbbq_2a_adv2():
             )
         },
         entity_descriptions={
+            DeviceKey(key="temperature_probe_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_probe_1", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="temperature_probe_2", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_probe_2", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
             DeviceKey(key="signal_strength", device_id=None): SensorDescription(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
                 device_class=SensorDeviceClass.SIGNAL_STRENGTH,
                 native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-            )
+            ),
         },
         entity_values={
+            DeviceKey(key="temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_probe_1", device_id=None),
+                name="Temperature " "Probe " "1",
+                native_value=15.4,
+            ),
+            DeviceKey(key="temperature_probe_2", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_probe_2", device_id=None),
+                name="Temperature " "Probe " "2",
+                native_value=1.9,
+            ),
             DeviceKey(key="signal_strength", device_id=None): SensorValue(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
                 name="Signal " "Strength",
                 native_value=-60,
-            )
+            ),
         },
         binary_entity_descriptions={},
         binary_entity_values={},
+        events={},
     )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,6 +99,93 @@ def test_sps():
     )
 
 
+def test_unknown_sps():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="sps",
+        manufacturer_data={
+            2063: b"\xc0\x12\x01p\x08d\x06",
+            2083: b"\x12\x01w\x08d\x06",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:21:09:09:65:49",
+        rssi=-54,
+        service_data={},
+        source="local",
+    )
+    assert parser.supported(service_info) is True
+
+
+def test_sps_th2_dupe_updates():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="sps",
+        manufacturer_data={2248: b"\x84\x14\x00\x88\x99d\x06"},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IBS-TH EEFF",
+                model="IBS-TH",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=DeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=DeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                device_class=DeviceClass.HUMIDITY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                native_value=100,
+                name="Battery",
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-60,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=22.48,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                native_value=52.52,
+                name="Humidity",
+            ),
+        },
+    )
+
+
 def test_sps_th2():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -132,6 +132,83 @@ def test_sps_variant():
     assert parser.supported(service_info) is True
 
 
+def test_sps_variant2():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="sps",
+        manufacturer_data={
+            2363: b"\xd0\x13\x00\xce\x90d\x06",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:22:03:25:01:46",
+        rssi=-96,
+        service_data={},
+        source="local",
+    )
+    assert parser.supported(service_info) is True
+    parser = INKBIRDBluetoothDeviceData()
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IBS-TH 0146",
+                model="IBS-TH",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                device_class=SensorDeviceClass.HUMIDITY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=100,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                name="Humidity",
+                native_value=50.72,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-96,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=23.63,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
 def test_sps_th2_dupe_updates():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -256,6 +256,73 @@ def test_sps_th2():
     )
 
 
+def test_unknown_tps():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="tps",
+        manufacturer_data={
+            2120: b"\x00\x00\x00\xc6n\r\x06",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:21:09:09:65:49",
+        rssi=-54,
+        service_data={},
+        source="local",
+    )
+    assert parser.supported(service_info) is True
+    parser = INKBIRDBluetoothDeviceData()
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IBS-TH2/P01B 6549",
+                model="IBS-TH2/P01B",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=21.2,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-54,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=13,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
 def test_ibbq_4():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(


### PR DESCRIPTION
Improves robustness of recovery on restart by detecting `"0000fff0-0000-1000-8000-00805f9b34fb"` as well