### PR TITLE
fix: handle sps broadcasting N0BYD

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -25,8 +25,10 @@ BBQ_LENGTH_TO_TYPE = {
     22: ("iBBQ-6", struct.Struct("<hhhhhh").unpack),
 }
 
+TH_NAMES = {"sps", "n0byd"}
+
 INKBIRD_NAMES = {
-    "sps": "IBS-TH",
+    **{name: "IBS-TH" for name in TH_NAMES},
     "tps": "IBS-TH2/P01B",
 }
 INKBIRD_UNPACK = struct.Struct("<hH").unpack
@@ -93,7 +95,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         if lower_name in INKBIRD_NAMES and msg_length == 9:
             (temp, hum) = INKBIRD_UNPACK(data[0:4])
             bat = int.from_bytes(data[7:8], "little")
-            if lower_name == "sps":
+            if lower_name in TH_NAMES:
                 self.update_predefined_sensor(
                     SensorLibrary.TEMPERATURE__CELSIUS, temp / 100
                 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -751,3 +751,76 @@ def test_xbbq_multiple_mfr_data():
         binary_entity_descriptions={},
         binary_entity_values={},
     )
+
+
+def test_n0byd():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="N0BYD",
+        manufacturer_data={63915: b"\x1b\x1e\x00H\xe37\x08"},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IBS-TH EEFF",
+                model="IBS-TH",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                device_class=SensorDeviceClass.HUMIDITY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=-16.21,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=55,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-60,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                name="Humidity",
+                native_value=77.07,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )


### PR DESCRIPTION
Sometimes the sps devices will use this name