### PR TITLE
feat: add support for the IAM-T1 Air Quality Sensor

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -72,7 +72,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             dev_type, _ = bbq_data
             self.set_device_name(f"{local_name} {short_address(address)}")
             self.set_device_type(f"{local_name[0]}{dev_type[1:]}")
-        elif (IAMT1_SERVICE_UUID in service_info.service_uuids):
+        elif IAMT1_SERVICE_UUID in service_info.service_uuids:
             self.set_device_name(f"{local_name} {short_address(address)}")
             self.set_device_type(f"{local_name}")
         else:
@@ -131,21 +131,14 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             temp = int.from_bytes(service_data[5:7], "big") / 10
             temp_sign = service_data[4] & 0xF
             temp = temp if temp_sign == 0 else -temp
-            #TODO Celsius vs Fahrenheit?
-            self.update_predefined_sensor(
-                SensorLibrary.TEMPERATURE__CELSIUS, temp
-            )
+            # TODO Celsius vs Fahrenheit?
+            self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temp)
             humidity = int.from_bytes(service_data[7:9], "big") / 10
-            self.update_predefined_sensor(
-                SensorLibrary.HUMIDITY__PERCENTAGE, humidity
-            )
+            self.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humidity)
             co2_ppm = int.from_bytes(service_data[9:11], "big")
             self.update_predefined_sensor(
                 SensorLibrary.CO2__CONCENTRATION_PARTS_PER_MILLION, co2_ppm
             )
             pressure_hpa = int.from_bytes(service_data[11:13], "big")
-            self.update_predefined_sensor(
-                SensorLibrary.PRESSURE__HPA, pressure_hpa
-            )
-            #TODO Battery
-
+            self.update_predefined_sensor(SensorLibrary.PRESSURE__HPA, pressure_hpa)
+            # TODO Battery

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -131,7 +131,6 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             temp = int.from_bytes(service_data[5:7], "big") / 10
             temp_sign = service_data[4] & 0xF
             temp = temp if temp_sign == 0 else -temp
-            # TODO Celsius vs Fahrenheit?
             self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temp)
             humidity = int.from_bytes(service_data[7:9], "big") / 10
             self.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humidity)

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -126,7 +126,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
                     key=f"temperature_probe_{num}",
                     name=f"Temperature Probe {num}",
                 )
-        elif IAMT1_SERVICE_UUID in service_info.service_uuids:
+        elif lower_name == "iam-t1" and IAMT1_SERVICE_UUID in service_info.service_uuids:
             service_data = service_info.service_data[IAMT1_SERVICE_UUID]
             temp = int.from_bytes(service_data[5:7], "big") / 10
             temp_sign = service_data[4] & 0xF

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -126,7 +126,9 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
                     key=f"temperature_probe_{num}",
                     name=f"Temperature Probe {num}",
                 )
-        elif lower_name == "iam-t1" and IAMT1_SERVICE_UUID in service_info.service_uuids:
+        elif (
+            lower_name == "iam-t1" and IAMT1_SERVICE_UUID in service_info.service_uuids
+        ):
             service_data = service_info.service_data[IAMT1_SERVICE_UUID]
             temp = int.from_bytes(service_data[5:7], "big") / 10
             temp_sign = service_data[4] & 0xF

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,7 @@ from sensor_state_data import (
     Units,
 )
 
-from inkbird_ble.parser import INKBIRDBluetoothDeviceData
+from inkbird_ble.parser import INKBIRDBluetoothDeviceData, IAMT1_SERVICE_UUID
 
 
 def test_can_create():
@@ -819,6 +819,103 @@ def test_n0byd():
                 name="Humidity",
                 native_value=77.07,
             ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
+def test_IAMT1():
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="IAM-T1",
+        manufacturer_data={12628: b"41\x43\x2d\x36\x32\x30\x30\x61\x31\x33\x35\x39\x38\x00\x00"},
+        service_uuids=[IAMT1_SERVICE_UUID],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={
+            IAMT1_SERVICE_UUID: b"\x55\xaa\x01\x10\x00\x00\xc4\x02\xda\x04\x58\x03\xee\x01\x00\xfe",
+        },  # 1112 PPM CO2, 19,6°C, 73% humidity, 1006 hPa
+        source="local",
+    )
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IAM-T1 EEFF",
+                model="IAM-T1",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            #TODO Battery
+            # DeviceKey(key="battery", device_id=None): SensorDescription(
+            #     device_key=DeviceKey(key="battery", device_id=None),
+            #     device_class=SensorDeviceClass.BATTERY,
+            #     native_unit_of_measurement=Units.PERCENTAGE,
+            # ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                device_class=SensorDeviceClass.HUMIDITY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key='carbon_dioxide', device_id=None): SensorDescription(
+                device_key=DeviceKey(key='carbon_dioxide', device_id=None),
+                device_class= SensorDeviceClass.CO2,
+                native_unit_of_measurement = Units.CONCENTRATION_PARTS_PER_MILLION,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=SensorDeviceClass.PRESSURE,
+                native_unit_of_measurement=Units.PRESSURE_HPA,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            #TODO Battery
+            # DeviceKey(key="battery", device_id=None): SensorValue(
+            #     device_key=DeviceKey(key="battery", device_id=None),
+            #     name="Battery",
+            #     native_value=55,
+            # ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-60,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                name="Humidity",
+                native_value=73.0,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value=1006,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=19.6,
+            ),
+            DeviceKey(key='carbon_dioxide', device_id=None): SensorValue(
+                device_key=DeviceKey(key='carbon_dioxide',
+                                     device_id=None),
+                name='Carbon Dioxide',
+                native_value=1112),
         },
         binary_entity_descriptions={},
         binary_entity_values={},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -838,7 +838,7 @@ def test_IAMT1():
         rssi=-60,
         service_data={
             IAMT1_SERVICE_UUID: (
-                b"\x55\xaa\x01\x10\x00\x00\xc4\x02" b"\xda\x04\x58\x03\xee\x01\x00\xfe"
+                b"\x55\xaa\x01\x10\x00\x00\xc4\x02\xda\x04\x58\x03\xee\x01\x00\xfe"
             ),
         },  # 1112 PPM CO2, 19,6°C, 73% humidity, 1006 hPa
         source="local",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -837,7 +837,10 @@ def test_IAMT1():
         address="aa:bb:cc:dd:ee:ff",
         rssi=-60,
         service_data={
-            IAMT1_SERVICE_UUID: b"\x55\xaa\x01\x10\x00\x00\xc4\x02\xda\x04\x58\x03\xee\x01\x00\xfe",
+            IAMT1_SERVICE_UUID: (
+                b"\x55\xaa\x01\x10\x00\x00\xc4\x02"
+                b"\xda\x04\x58\x03\xee\x01\x00\xfe"
+             ),
         },  # 1112 PPM CO2, 19,6°C, 73% humidity, 1006 hPa
         source="local",
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,7 @@ from sensor_state_data import (
     Units,
 )
 
-from inkbird_ble.parser import INKBIRDBluetoothDeviceData, IAMT1_SERVICE_UUID
+from inkbird_ble.parser import IAMT1_SERVICE_UUID, INKBIRDBluetoothDeviceData
 
 
 def test_can_create():
@@ -830,7 +830,9 @@ def test_IAMT1():
     parser = INKBIRDBluetoothDeviceData()
     service_info = BluetoothServiceInfo(
         name="IAM-T1",
-        manufacturer_data={12628: b"41\x43\x2d\x36\x32\x30\x30\x61\x31\x33\x35\x39\x38\x00\x00"},
+        manufacturer_data={
+            12628: b"41\x43\x2d\x36\x32\x30\x30\x61\x31\x33\x35\x39\x38\x00\x00"
+        },
         service_uuids=[IAMT1_SERVICE_UUID],
         address="aa:bb:cc:dd:ee:ff",
         rssi=-60,
@@ -852,7 +854,7 @@ def test_IAMT1():
             )
         },
         entity_descriptions={
-            #TODO Battery
+            # TODO Battery
             # DeviceKey(key="battery", device_id=None): SensorDescription(
             #     device_key=DeviceKey(key="battery", device_id=None),
             #     device_class=SensorDeviceClass.BATTERY,
@@ -868,10 +870,10 @@ def test_IAMT1():
                 device_class=SensorDeviceClass.HUMIDITY,
                 native_unit_of_measurement=Units.PERCENTAGE,
             ),
-            DeviceKey(key='carbon_dioxide', device_id=None): SensorDescription(
-                device_key=DeviceKey(key='carbon_dioxide', device_id=None),
-                device_class= SensorDeviceClass.CO2,
-                native_unit_of_measurement = Units.CONCENTRATION_PARTS_PER_MILLION,
+            DeviceKey(key="carbon_dioxide", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="carbon_dioxide", device_id=None),
+                device_class=SensorDeviceClass.CO2,
+                native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
             ),
             DeviceKey(key="pressure", device_id=None): SensorDescription(
                 device_key=DeviceKey(key="pressure", device_id=None),
@@ -885,7 +887,7 @@ def test_IAMT1():
             ),
         },
         entity_values={
-            #TODO Battery
+            # TODO Battery
             # DeviceKey(key="battery", device_id=None): SensorValue(
             #     device_key=DeviceKey(key="battery", device_id=None),
             #     name="Battery",
@@ -911,11 +913,11 @@ def test_IAMT1():
                 name="Temperature",
                 native_value=19.6,
             ),
-            DeviceKey(key='carbon_dioxide', device_id=None): SensorValue(
-                device_key=DeviceKey(key='carbon_dioxide',
-                                     device_id=None),
-                name='Carbon Dioxide',
-                native_value=1112),
+            DeviceKey(key="carbon_dioxide", device_id=None): SensorValue(
+                device_key=DeviceKey(key="carbon_dioxide", device_id=None),
+                name="Carbon Dioxide",
+                native_value=1112,
+            ),
         },
         binary_entity_descriptions={},
         binary_entity_values={},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -838,9 +838,8 @@ def test_IAMT1():
         rssi=-60,
         service_data={
             IAMT1_SERVICE_UUID: (
-                b"\x55\xaa\x01\x10\x00\x00\xc4\x02"
-                b"\xda\x04\x58\x03\xee\x01\x00\xfe"
-             ),
+                b"\x55\xaa\x01\x10\x00\x00\xc4\x02" b"\xda\x04\x58\x03\xee\x01\x00\xfe"
+            ),
         },  # 1112 PPM CO2, 19,6°C, 73% humidity, 1006 hPa
         source="local",
     )


### PR DESCRIPTION
#34 
I created an implementation for the IAM-T1 Air Quality sensor including tests. The following sensors are calculated:

- Temperature (°C)
- Humidity (%)
- CO2 (PPM)
- Pressure (hPa)

I took the byte numbers from https://smarthomescene.com/guides/how-to-integrate-inkbird-iam-t1-air-quality-monitor-in-home-assistant/ and figured out the service UUID with `bluetoothctl`. Then I wrote the test against a real payload from my device for which I knew the decoded values.

I'm not sure if my implementation works. Is is the first one to use a non-empty `service_data` and I never implemented anything to do with BLE. Is there any way I can test the implementation with my real IAM-T1, without having to build my own home assistant version? Please advise.