### PR TITLE
feat: use changed_manufacturer_data from newer bluetooth-sensor-state-data

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -184,22 +184,23 @@ docs = ["Sphinx (>=5,<9)", "myst-parser (>=0.18,<4.1)", "sphinx-rtd-theme (>=1,<
 
 [[package]]
 name = "bluetooth-sensor-state-data"
-version = "1.7.5"
+version = "1.8.0"
 description = "Models for storing and converting Bluetooth Sensor State Data"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "bluetooth_sensor_state_data-1.7.5-py3-none-any.whl", hash = "sha256:a4ce3cce9839422299209e5427a6ce24061ff844fbdb61af2a485e480b8d7e23"},
-    {file = "bluetooth_sensor_state_data-1.7.5.tar.gz", hash = "sha256:be9319a3d70745e11689e91c013bf71d0d5570d303a49d21668777ea7854227a"},
+    {file = "bluetooth_sensor_state_data-1.8.0-py3-none-any.whl", hash = "sha256:c001541d176da0071dd96b63e6327e7afa158c88726fd638b77042d8d823ca6c"},
+    {file = "bluetooth_sensor_state_data-1.8.0.tar.gz", hash = "sha256:b97a6c29da8b1c430e2524c1b1267e9981bee15d5cdf49f33c8b6e40ed69c9e8"},
 ]
 
 [package.dependencies]
-home-assistant-bluetooth = ">=1.3.0"
+bluetooth-data-tools = ">=1.28.0"
+habluetooth = ">=3.42.0"
 sensor-state-data = ">=2.0"
 
 [package.extras]
-docs = ["Sphinx (>=5,<7)", "myst-parser (>=0.18,<3.1)", "sphinx-rtd-theme (>=1,<4)"]
+docs = ["Sphinx (>=5,<8)", "myst-parser (>=0.18,<3.1)", "sphinx-rtd-theme (>=1,<4)"]
 
 [[package]]
 name = "btsocket"
@@ -688,21 +689,6 @@ bluetooth-adapters = ">=0.16.1"
 bluetooth-auto-recovery = ">=1.2.3"
 bluetooth-data-tools = ">=1.28.0"
 dbus-fast = {version = ">=2.30.2", markers = "platform_system == \"Linux\""}
-
-[[package]]
-name = "home-assistant-bluetooth"
-version = "1.13.1"
-description = "Home Assistant Bluetooth Models and Helpers"
-optional = false
-python-versions = ">=3.11"
-groups = ["main"]
-files = [
-    {file = "home_assistant_bluetooth-1.13.1-py3-none-any.whl", hash = "sha256:cdf13b5b45f7744165677831e309ee78fbaf0c2866c6b5931e14d1e4e7dae5d7"},
-    {file = "home_assistant_bluetooth-1.13.1.tar.gz", hash = "sha256:0ae0e2a8491cc762ee9e694b8bc7665f1e2b4618926f63969a23a2e3a48ce55e"},
-]
-
-[package.dependencies]
-habluetooth = ">=3.0"
 
 [[package]]
 name = "idna"
@@ -1771,5 +1757,5 @@ docs = ["Sphinx", "myst-parser", "sphinx-rtd-theme"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "c8efb30588fb025b5d173fb6c807fb0a9c39ff02c072425fb249193e6a372bd8"
+python-versions = ">=3.11,<3.14"
+content-hash = "8a08e9b003e4f7470eb25dfc96b00919161417ed57c1ceef5258962f74c85ce4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ packages = [
 "Changelog" = "https://github.com/bluetooth-devices/inkbird-ble/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = ">=3.11,<3.14"
 
 # Documentation Dependencies
 Sphinx = {version = ">=5,<9", optional = true}
 sphinx-rtd-theme = {version = ">=1,<4", optional = true}
 myst-parser = {version = ">=0.18,<4.1", optional = true}
-bluetooth-sensor-state-data = ">=1.6.1"
+bluetooth-sensor-state-data = ">=1.8.0"
 habluetooth = {version = ">=3.42.0", python = ">=3.11,<3.14"}
 sensor-state-data = ">=2.2.0"
 bluetooth-data-tools = ">=1.28.0"

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -23,7 +23,6 @@ from bleak.exc import BleakCharacteristicNotFoundError, BleakError
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from bluetooth_data_tools import (
     monotonic_time_coarse,
-    parse_advertisement_data_bytes,
     short_address,
 )
 from bluetooth_sensor_state_data import BluetoothData, SensorUpdate
@@ -482,25 +481,10 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         if not MODEL_INFO[self._device_type].parse_adv:
             # Device does not support parsing advertisement data
             return
-        changed_manufacturer_data: dict[int, bytes] | None = None
-        if service_info.raw:
-            # If we have the raw data we don't need to work out
-            # which one is the newest.
-            _, _, _, raw_manufacturer_data, _ = parse_advertisement_data_bytes(
-                service_info.raw
-            )
-            changed_manufacturer_data = {
-                k: v
-                for k, v in raw_manufacturer_data.items()
-                if k not in MANUFACTURER_DATA_ID_EXCLUDES
-            }
-        else:
-            excludes = (
-                MANUFACTURER_DATA_ID_EXCLUDES if len(manufacturer_data) > 1 else None
-            )
-            changed_manufacturer_data = self.changed_manufacturer_data(
-                service_info, excludes
-            )
+        excludes = MANUFACTURER_DATA_ID_EXCLUDES if len(manufacturer_data) > 1 else None
+        changed_manufacturer_data = self.changed_manufacturer_data(
+            service_info, excludes
+        )
         if not changed_manufacturer_data or len(changed_manufacturer_data) > 1:
             # If len(changed_manufacturer_data) > 1 it means we switched
             # ble adapters so we do not know which data is the latest


### PR DESCRIPTION
1.8.0+ knows about raw so we do not have to implement it ourselves