### PR TITLE
feat: add support for IAM-T2

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -273,7 +273,7 @@ SEVENTEEN_BYTE_SENSOR_MODELS = {
     model_type
     for model_type, model_info in MODEL_INFO.items()
     if model_info.model_type is ModelType.SENSOR
-    and model_info.message_length == 17
+    and model_info.message_length == 17  # noqa: PLR2004
     and model_info.parse_adv
 }
 SENSOR_MODELS = {
@@ -668,19 +668,19 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         # IAM-T2 broadcasts 15 bytes of manufacturer data
         # Format: MAC(6) + 0xE5(1) + 0x24(1) + status(1) + temp(1) + hum(2) +
         #         co2(2) + battery(1)
-        if len(data) < 17:  # 2 bytes manufacturer ID + 15 bytes data
+        if len(data) < 17:  # 2 bytes manufacturer ID + 15 bytes data # noqa: PLR2004
             _LOGGER.debug("IAM-T2: Invalid data length: %s", len(data))
             return
 
         # Skip the first 2 bytes (manufacturer ID)
         iam_data = data[2:]
 
-        if len(iam_data) != 15:
+        if len(iam_data) != 15:  # noqa: PLR2004
             _LOGGER.debug("IAM-T2: Invalid manufacturer data length: %s", len(iam_data))
             return
 
         # Validate fixed bytes
-        if iam_data[6] != 0xE5 or iam_data[7] != 0x24:
+        if iam_data[6] != 0xE5 or iam_data[7] != 0x24:  # noqa: PLR2004
             _LOGGER.debug(
                 "IAM-T2: Invalid fixed bytes: %02x %02x", iam_data[6], iam_data[7]
             )

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -272,7 +272,9 @@ EIGHTEEN_BYTE_SENSOR_MODELS = {
 SEVENTEEN_BYTE_SENSOR_MODELS = {
     model_type
     for model_type, model_info in MODEL_INFO.items()
-    if model_info.model_type is ModelType.SENSOR and model_info.message_length == 17 and model_info.parse_adv  # noqa: PLR2004
+    if model_info.model_type is ModelType.SENSOR
+    and model_info.message_length == 17
+    and model_info.parse_adv
 }
 SENSOR_MODELS = {
     *NINE_BYTE_SENSOR_MODELS,
@@ -664,7 +666,8 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
     def _update_seventeen_byte_model(self, data: bytes, msg_length: int) -> None:
         """Update the sensor values for 17-byte sensor models (IAM-T2)."""
         # IAM-T2 broadcasts 15 bytes of manufacturer data
-        # Format: MAC(6) + 0xE5(1) + 0x24(1) + status(1) + temp(1) + hum(2) + co2(2) + battery(1)
+        # Format: MAC(6) + 0xE5(1) + 0x24(1) + status(1) + temp(1) + hum(2) +
+        #         co2(2) + battery(1)
         if len(data) < 17:  # 2 bytes manufacturer ID + 15 bytes data
             _LOGGER.debug("IAM-T2: Invalid data length: %s", len(data))
             return
@@ -678,14 +681,17 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
 
         # Validate fixed bytes
         if iam_data[6] != 0xE5 or iam_data[7] != 0x24:
-            _LOGGER.debug("IAM-T2: Invalid fixed bytes: %02x %02x", iam_data[6], iam_data[7])
+            _LOGGER.debug(
+                "IAM-T2: Invalid fixed bytes: %02x %02x", iam_data[6], iam_data[7]
+            )
             return
 
         # Parse sensor values
         temperature = iam_data[9] / 10.0
         humidity = ((iam_data[10] << 8) | iam_data[11]) / 10.0
         co2 = (iam_data[12] << 8) | iam_data[13]
-        # Note: byte 14 appears to be battery-related but encoding is unclear (always 213/0xD5)
+        # Note: byte 14 appears to be battery-related but encoding is unclear
+        # (always 213/0xD5)
 
         self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temperature)
         self.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humidity)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2707,3 +2707,79 @@ def test_iam_t2_detection() -> None:
     assert parser.device_type == Model.IAM_T2
     assert parser.supported(service_info) is True
     assert parser.uses_notify is False
+
+
+def test_iam_t2_sensor_data() -> None:
+    """Test IAM-T2 sensor data parsing from advertisement data."""
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e38e52400b402700326d5")},
+        service_uuids=[],
+        address="62:00:A1:3E:38:E5",
+        rssi=-79,
+        service_data={},
+        source="local",
+    )
+    assert parser.supported(service_info) is True
+    assert parser.device_type == Model.IAM_T2
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="IAM-T2 38E5",
+                model="IAM-T2",
+                manufacturer="INKBIRD",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                device_class=SensorDeviceClass.HUMIDITY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="carbon_dioxide", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="carbon_dioxide", device_id=None),
+                device_class=SensorDeviceClass.CO2,
+                native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-79,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=18.0,
+            ),
+            DeviceKey(key="humidity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity", device_id=None),
+                name="Humidity",
+                native_value=62.4,
+            ),
+            DeviceKey(key="carbon_dioxide", device_id=None): SensorValue(
+                device_key=DeviceKey(key="carbon_dioxide", device_id=None),
+                name="Carbon Dioxide",
+                native_value=806,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2689,3 +2689,21 @@ def test_IBS_P02B_multiple_updates():
         result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
         == 37.4
     )
+
+
+def test_iam_t2_detection() -> None:
+    """Test IAM-T2 device detection from advertisement data."""
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e38e52400b402700326d5")},
+        service_uuids=[],
+        address="62:00:A1:3E:38:E5",
+        rssi=-79,
+        service_data={},
+        source="local",
+    )
+    parser = INKBIRDBluetoothDeviceData()
+    parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert parser.supported(service_info) is True
+    assert parser.uses_notify is False

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2891,3 +2891,39 @@ def test_iam_t2_fahrenheit_mode_82f() -> None:
         ].native_value
         == 667
     )
+
+
+def test_iam_t2_detection_without_name() -> None:
+    """Test IAM-T2 device detection from manufacturer data alone without device name."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Real data but with empty/generic name to test manufacturer data detection
+    service_info = make_bluetooth_service_info(
+        name="",  # Empty name to force detection via manufacturer data
+        manufacturer_data={12884: bytes.fromhex("006200a13e29bed4011701ee025391")},
+        service_uuids=[],
+        address="62:00:A1:3E:29:BE",
+        rssi=-65,
+        service_data={},
+        source="Core Bluetooth",
+    )
+    assert parser.supported(service_info) is True
+    assert parser.device_type == Model.IAM_T2
+
+    result = parser.update(service_info)
+    assert result is not None
+
+    # Verify it still parses data correctly
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 27.9
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 49.4
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 595
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2822,3 +2822,72 @@ def test_iam_t2_fahrenheit_mode() -> None:
         ].native_value
         == 576
     )
+
+
+def test_iam_t2_celsius_mode() -> None:
+    """Test IAM-T2 in Celsius mode with real data."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Real data from user: 27.9°C, 49.4% humidity, 595 CO2
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e29bed4011701ee025391")},
+        service_uuids=[],
+        address="62:00:A1:3E:29:BE",
+        rssi=-65,
+        service_data={},
+        source="Core Bluetooth",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    # Temperature in Celsius mode
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 27.9
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 49.4
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 595
+    )
+
+
+def test_iam_t2_fahrenheit_mode_82f() -> None:
+    """Test IAM-T2 in Fahrenheit mode with 82°F data."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Real data from user: 82.0°F, 52.3% humidity, 667 CO2
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e29bed60334020b029b91")},
+        service_uuids=[],
+        address="62:00:A1:3E:29:BE",
+        rssi=-73,
+        service_data={},
+        source="Core Bluetooth",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    # 82.0°F = 27.78°C
+    assert (
+        round(
+            result.entity_values[
+                DeviceKey(key="temperature", device_id=None)
+            ].native_value,
+            1,
+        )
+        == 27.8
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 52.3
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 667
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2693,14 +2693,15 @@ def test_IBS_P02B_multiple_updates():
 
 def test_iam_t2_detection() -> None:
     """Test IAM-T2 device detection from advertisement data."""
+    # Using real data from issue #96
     service_info = make_bluetooth_service_info(
         name="Ink@IAM-T2",
-        manufacturer_data={12884: bytes.fromhex("006200a13e38e52400b402700326d5")},
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202d001be025f72")},
         service_uuids=[],
-        address="62:00:A1:3E:38:E5",
-        rssi=-79,
+        address="62:00:A1:3E:2C:6A",
+        rssi=-78,
         service_data={},
-        source="local",
+        source="Core Bluetooth",
     )
     parser = INKBIRDBluetoothDeviceData()
     parser.update(service_info)
@@ -2712,14 +2713,15 @@ def test_iam_t2_detection() -> None:
 def test_iam_t2_sensor_data() -> None:
     """Test IAM-T2 sensor data parsing from advertisement data."""
     parser = INKBIRDBluetoothDeviceData()
+    # Real data from user: 28.2°C, 55% humidity, 615 CO2
     service_info = make_bluetooth_service_info(
         name="Ink@IAM-T2",
-        manufacturer_data={12884: bytes.fromhex("006200a13e38e52400b402700326d5")},
+        manufacturer_data={12884: bytes.fromhex("006200a13e29bed4011a0227026791")},
         service_uuids=[],
-        address="62:00:A1:3E:38:E5",
-        rssi=-79,
+        address="62:00:A1:3E:29:BE",
+        rssi=-67,
         service_data={},
-        source="local",
+        source="Core Bluetooth",
     )
     assert parser.supported(service_info) is True
     assert parser.device_type == Model.IAM_T2
@@ -2728,7 +2730,7 @@ def test_iam_t2_sensor_data() -> None:
         title=None,
         devices={
             None: SensorDeviceInfo(
-                name="IAM-T2 38E5",
+                name="IAM-T2 29BE",
                 model="IAM-T2",
                 manufacturer="INKBIRD",
                 sw_version=None,
@@ -2761,22 +2763,22 @@ def test_iam_t2_sensor_data() -> None:
             DeviceKey(key="signal_strength", device_id=None): SensorValue(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
                 name="Signal Strength",
-                native_value=-79,
+                native_value=-67,
             ),
             DeviceKey(key="temperature", device_id=None): SensorValue(
                 device_key=DeviceKey(key="temperature", device_id=None),
                 name="Temperature",
-                native_value=18.0,
+                native_value=28.2,
             ),
             DeviceKey(key="humidity", device_id=None): SensorValue(
                 device_key=DeviceKey(key="humidity", device_id=None),
                 name="Humidity",
-                native_value=62.4,
+                native_value=55.1,
             ),
             DeviceKey(key="carbon_dioxide", device_id=None): SensorValue(
                 device_key=DeviceKey(key="carbon_dioxide", device_id=None),
                 name="Carbon Dioxide",
-                native_value=806,
+                native_value=615,
             ),
         },
         binary_entity_descriptions={},
@@ -2785,164 +2787,38 @@ def test_iam_t2_sensor_data() -> None:
     )
 
 
-def test_iam_t2_real_world_data_1() -> None:
-    """Test IAM-T2 with real-world data from issue #96 - example 1."""
+def test_iam_t2_fahrenheit_mode() -> None:
+    """Test IAM-T2 in Fahrenheit mode with real data."""
     parser = INKBIRDBluetoothDeviceData()
-    # Data: 006200a13e2c6a4202d001be025f72
-    # MAC: 62:00:A1:3E:2C:6A, temp: d0 (208/10=20.8°C), hum: 01be (446/10=44.6%),
-    # co2: 025f (607 ppm)
+    # Real data from user: 82.8°F, 45.7% humidity, 576 CO2
     service_info = make_bluetooth_service_info(
         name="Ink@IAM-T2",
-        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202d001be025f72")},
+        manufacturer_data={12884: bytes.fromhex("006200a13e29bed6033c01c9024091")},
         service_uuids=[],
-        address="62:00:A1:3E:2C:6A",
-        rssi=-78,
+        address="62:00:A1:3E:29:BE",
+        rssi=-66,
         service_data={},
         source="Core Bluetooth",
     )
     result = parser.update(service_info)
     assert parser.device_type == Model.IAM_T2
+    # 82.8°F = 28.22°C
     assert (
-        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 20.8
+        round(
+            result.entity_values[
+                DeviceKey(key="temperature", device_id=None)
+            ].native_value,
+            1,
+        )
+        == 28.2
     )
     assert (
         result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 44.6
+        == 45.7
     )
     assert (
         result.entity_values[
             DeviceKey(key="carbon_dioxide", device_id=None)
         ].native_value
-        == 607
-    )
-
-
-def test_iam_t2_real_world_data_2() -> None:
-    """Test IAM-T2 with real-world data from issue #96 - example 2."""
-    parser = INKBIRDBluetoothDeviceData()
-    # Data: 006200a13e2c6a4202ca01bd02Mr
-    # MAC: 62:00:A1:3E:2C:6A, temp: ca (202/10=20.2°C), hum: 01bd (445/10=44.5%),
-    # co2: 024d (589 ppm)
-    service_info = make_bluetooth_service_info(
-        name="Ink@IAM-T2",
-        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202ca01bd024d72")},
-        service_uuids=[],
-        address="62:00:A1:3E:2C:6A",
-        rssi=-75,
-        service_data={},
-        source="Core Bluetooth",
-    )
-    result = parser.update(service_info)
-    assert parser.device_type == Model.IAM_T2
-    assert (
-        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 20.2
-    )
-    assert (
-        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 44.5
-    )
-    assert (
-        result.entity_values[
-            DeviceKey(key="carbon_dioxide", device_id=None)
-        ].native_value
-        == 589
-    )
-
-
-def test_iam_t2_real_world_data_3() -> None:
-    """Test IAM-T2 with real-world data from issue #96 - example 3."""
-    parser = INKBIRDBluetoothDeviceData()
-    # Data: 006200a13e2c6a4202be01b7024372
-    # MAC: 62:00:A1:3E:2C:6A, temp: be (190/10=19.0°C), hum: 01b7 (439/10=43.9%),
-    # co2: 0243 (579 ppm)
-    service_info = make_bluetooth_service_info(
-        name="62-00-A1-3E-2C-6A",
-        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202be01b7024372")},
-        service_uuids=[],
-        address="62:00:A1:3E:2C:6A",
-        rssi=-82,
-        service_data={},
-        source="00:1A:7D:DA:71:14",
-    )
-    result = parser.update(service_info)
-    assert parser.device_type == Model.IAM_T2
-    assert (
-        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 19.0
-    )
-    assert (
-        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 43.9
-    )
-    assert (
-        result.entity_values[
-            DeviceKey(key="carbon_dioxide", device_id=None)
-        ].native_value
-        == 579
-    )
-
-
-def test_iam_t2_real_world_data_4() -> None:
-    """Test IAM-T2 with real-world data from issue #96 - example 4."""
-    parser = INKBIRDBluetoothDeviceData()
-    # Data: 006200a13e2c6a4202bf01b8023372
-    # MAC: 62:00:A1:3E:2C:6A, temp: bf (191/10=19.1°C), hum: 01b8 (440/10=44.0%),
-    # co2: 0233 (563 ppm)
-    service_info = make_bluetooth_service_info(
-        name="62-00-A1-3E-2C-6A",
-        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202bf01b8023372")},
-        service_uuids=[],
-        address="62:00:A1:3E:2C:6A",
-        rssi=-82,
-        service_data={},
-        source="00:1A:7D:DA:71:14",
-    )
-    result = parser.update(service_info)
-    assert parser.device_type == Model.IAM_T2
-    assert (
-        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 19.1
-    )
-    assert (
-        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 44.0
-    )
-    assert (
-        result.entity_values[
-            DeviceKey(key="carbon_dioxide", device_id=None)
-        ].native_value
-        == 563
-    )
-
-
-def test_iam_t2_passive_scanner_data() -> None:
-    """Test IAM-T2 with data from passive scanner (no device name)."""
-    parser = INKBIRDBluetoothDeviceData()
-    # Data from passive scanner with no device name
-    service_info = make_bluetooth_service_info(
-        name="62:00:A1:3E:2C:6A",
-        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202ca01bc023a72")},
-        service_uuids=[],
-        address="62:00:A1:3E:2C:6A",
-        rssi=-85,
-        service_data={},
-        source="24:4C:AB:03:0B:6E",
-    )
-    result = parser.update(service_info)
-    assert parser.device_type == Model.IAM_T2
-    assert (
-        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 20.2
-    )
-    assert (
-        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 44.4
-    )
-    assert (
-        result.entity_values[
-            DeviceKey(key="carbon_dioxide", device_id=None)
-        ].native_value
-        == 570
+        == 576
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2783,3 +2783,166 @@ def test_iam_t2_sensor_data() -> None:
         binary_entity_values={},
         events={},
     )
+
+
+def test_iam_t2_real_world_data_1() -> None:
+    """Test IAM-T2 with real-world data from issue #96 - example 1."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Data: 006200a13e2c6a4202d001be025f72
+    # MAC: 62:00:A1:3E:2C:6A, temp: d0 (208/10=20.8°C), hum: 01be (446/10=44.6%),
+    # co2: 025f (607 ppm)
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202d001be025f72")},
+        service_uuids=[],
+        address="62:00:A1:3E:2C:6A",
+        rssi=-78,
+        service_data={},
+        source="Core Bluetooth",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 20.8
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 44.6
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 607
+    )
+
+
+def test_iam_t2_real_world_data_2() -> None:
+    """Test IAM-T2 with real-world data from issue #96 - example 2."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Data: 006200a13e2c6a4202ca01bd02Mr
+    # MAC: 62:00:A1:3E:2C:6A, temp: ca (202/10=20.2°C), hum: 01bd (445/10=44.5%),
+    # co2: 024d (589 ppm)
+    service_info = make_bluetooth_service_info(
+        name="Ink@IAM-T2",
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202ca01bd024d72")},
+        service_uuids=[],
+        address="62:00:A1:3E:2C:6A",
+        rssi=-75,
+        service_data={},
+        source="Core Bluetooth",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 20.2
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 44.5
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 589
+    )
+
+
+def test_iam_t2_real_world_data_3() -> None:
+    """Test IAM-T2 with real-world data from issue #96 - example 3."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Data: 006200a13e2c6a4202be01b7024372
+    # MAC: 62:00:A1:3E:2C:6A, temp: be (190/10=19.0°C), hum: 01b7 (439/10=43.9%),
+    # co2: 0243 (579 ppm)
+    service_info = make_bluetooth_service_info(
+        name="62-00-A1-3E-2C-6A",
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202be01b7024372")},
+        service_uuids=[],
+        address="62:00:A1:3E:2C:6A",
+        rssi=-82,
+        service_data={},
+        source="00:1A:7D:DA:71:14",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 19.0
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 43.9
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 579
+    )
+
+
+def test_iam_t2_real_world_data_4() -> None:
+    """Test IAM-T2 with real-world data from issue #96 - example 4."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Data: 006200a13e2c6a4202bf01b8023372
+    # MAC: 62:00:A1:3E:2C:6A, temp: bf (191/10=19.1°C), hum: 01b8 (440/10=44.0%),
+    # co2: 0233 (563 ppm)
+    service_info = make_bluetooth_service_info(
+        name="62-00-A1-3E-2C-6A",
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202bf01b8023372")},
+        service_uuids=[],
+        address="62:00:A1:3E:2C:6A",
+        rssi=-82,
+        service_data={},
+        source="00:1A:7D:DA:71:14",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 19.1
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 44.0
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 563
+    )
+
+
+def test_iam_t2_passive_scanner_data() -> None:
+    """Test IAM-T2 with data from passive scanner (no device name)."""
+    parser = INKBIRDBluetoothDeviceData()
+    # Data from passive scanner with no device name
+    service_info = make_bluetooth_service_info(
+        name="62:00:A1:3E:2C:6A",
+        manufacturer_data={12884: bytes.fromhex("006200a13e2c6a4202ca01bc023a72")},
+        service_uuids=[],
+        address="62:00:A1:3E:2C:6A",
+        rssi=-85,
+        service_data={},
+        source="24:4C:AB:03:0B:6E",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IAM_T2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 20.2
+    )
+    assert (
+        result.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 44.4
+    )
+    assert (
+        result.entity_values[
+            DeviceKey(key="carbon_dioxide", device_id=None)
+        ].native_value
+        == 570
+    )


### PR DESCRIPTION
This pull request adds support for a new sensor model, IAM-T2, to the `inkbird_ble` parser. The changes include defining the new model, updating the parsing logic, and adding a test case to ensure proper functionality.

### Support for IAM-T2 model:

* Added `IAM_T2` to the `Model` enum in `src/inkbird_ble/parser.py`.
* Defined `ModelInfo` for `IAM_T2` with its specific attributes, including `local_name`, `message_length`, and `unpacker`.
* Introduced a new set, `SEVENTEEN_BYTE_SENSOR_MODELS`, to handle 17-byte sensor models and integrated it into the `SENSOR_MODELS` aggregation.

### Parsing logic updates:

* Updated the `_start_update` method to detect IAM-T2 devices based on manufacturer data.
* Added `_update_seventeen_byte_model` to parse sensor data specific to IAM-T2, including temperature, humidity, and CO2 concentration.
* Registered `_update_seventeen_byte_model` in the `_device_type_dispatch` mapping for IAM-T2.

### Testing:

* Added a new test case, `test_iam_t2_detection` and `test_iam_t2_sensor_data`, to verify IAM-T2 device detection, sensor data and ensure correct parsing of advertisement data.
* Tested locally using device and using debug information provided in #96

Closes #96 