### PR TITLE
feat: add support for IBT-4WB

### DIFF
--- a/docs/source/supported_devices.md
+++ b/docs/source/supported_devices.md
@@ -6,24 +6,24 @@ member of the `Model` enum (importable from `inkbird_ble`); pass it to
 the parser detects it from the first advertisement (passive devices) or you
 must supply it (notify-only devices).
 
-| Model                   | Family                | Transport          | Detection                          | Sensors                                                             |
-| ----------------------- | --------------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------- |
-| `IBS-TH`                | Hygrometer            | advertisement      | local name `sps`                   | temperature, humidity, battery                                      |
-| `IBS-TH2` / `P01B`      | Hygrometer            | advertisement      | local name `tps`                   | temperature, humidity, battery                                      |
-| `IBS-P02B`              | Pool / probe          | advertisement only | local name `ibs-p02b`              | temperature, battery                                                |
-| `ITH-11-B`              | Hygrometer            | advertisement      | local name `ith-11-b`              | temperature, humidity, battery                                      |
-| `ITH-13-B`              | Hygrometer            | advertisement      | local name `ith-13-b`              | temperature, humidity, battery                                      |
-| `ITH-21-B`              | Hygrometer            | advertisement      | local name `ith-21-b`              | temperature, humidity, battery                                      |
-| `IAM-T1`                | Indoor air quality    | GATT notify        | manufacturer-data `AC-6200` prefix | temperature, humidity, CO₂, atmospheric pressure                    |
-| `IAM-T2`                | Indoor air quality    | advertisement      | 17-byte payload + MAC prefix       | temperature, humidity, CO₂                                          |
-| `IHT-2PB`               | 3-probe thermometer   | GATT notify        | local name `Ink@IHT-2PB#…`         | temperature × 3 probes                                              |
-| `IBT-4WB`               | 4-probe BBQ thermometer | GATT notify      | local name `Inkbird@IBT-24SPH`     | temperature × 4 probes, battery                                     |
-| `INT-11P-B`             | Connected BBQ probe   | GATT poll          | local name `int-11p-b`             | probe temperature, ambient temperature, probe battery, case battery |
-| `iBBQ-1`                | BBQ probe (1 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 1                                                     |
-| `iBBQ-2`                | BBQ probe (2 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 2                                                     |
-| `iBBQ-4`                | BBQ probe (4 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 4                                                     |
-| `iBBQ-6`                | BBQ probe (6 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 6                                                     |
-| `Generic 18 byte model` | Unknown hygrometer    | advertisement      | 18-byte payload + service UUID     | temperature, humidity, battery                                      |
+| Model                   | Family                  | Transport          | Detection                          | Sensors                                                             |
+| ----------------------- | ----------------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------- |
+| `IBS-TH`                | Hygrometer              | advertisement      | local name `sps`                   | temperature, humidity, battery                                      |
+| `IBS-TH2` / `P01B`      | Hygrometer              | advertisement      | local name `tps`                   | temperature, humidity, battery                                      |
+| `IBS-P02B`              | Pool / probe            | advertisement only | local name `ibs-p02b`              | temperature, battery                                                |
+| `ITH-11-B`              | Hygrometer              | advertisement      | local name `ith-11-b`              | temperature, humidity, battery                                      |
+| `ITH-13-B`              | Hygrometer              | advertisement      | local name `ith-13-b`              | temperature, humidity, battery                                      |
+| `ITH-21-B`              | Hygrometer              | advertisement      | local name `ith-21-b`              | temperature, humidity, battery                                      |
+| `IAM-T1`                | Indoor air quality      | GATT notify        | manufacturer-data `AC-6200` prefix | temperature, humidity, CO₂, atmospheric pressure                    |
+| `IAM-T2`                | Indoor air quality      | advertisement      | 17-byte payload + MAC prefix       | temperature, humidity, CO₂                                          |
+| `IHT-2PB`               | 3-probe thermometer     | GATT notify        | local name `Ink@IHT-2PB#…`         | temperature × 3 probes                                              |
+| `IBT-4WB`               | 4-probe BBQ thermometer | GATT notify        | local name `Inkbird@IBT-24SPH`     | temperature × 4 probes, battery                                     |
+| `INT-11P-B`             | Connected BBQ probe     | GATT poll          | local name `int-11p-b`             | probe temperature, ambient temperature, probe battery, case battery |
+| `iBBQ-1`                | BBQ probe (1 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 1                                                     |
+| `iBBQ-2`                | BBQ probe (2 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 2                                                     |
+| `iBBQ-4`                | BBQ probe (4 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 4                                                     |
+| `iBBQ-6`                | BBQ probe (6 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 6                                                     |
+| `Generic 18 byte model` | Unknown hygrometer      | advertisement      | 18-byte payload + service UUID     | temperature, humidity, battery                                      |
 
 ## Transport guide
 

--- a/docs/source/supported_devices.md
+++ b/docs/source/supported_devices.md
@@ -17,6 +17,7 @@ must supply it (notify-only devices).
 | `IAM-T1`                | Indoor air quality    | GATT notify        | manufacturer-data `AC-6200` prefix | temperature, humidity, CO₂, atmospheric pressure                    |
 | `IAM-T2`                | Indoor air quality    | advertisement      | 17-byte payload + MAC prefix       | temperature, humidity, CO₂                                          |
 | `IHT-2PB`               | 3-probe thermometer   | GATT notify        | local name `Ink@IHT-2PB#…`         | temperature × 3 probes                                              |
+| `IBT-4WB`               | 4-probe BBQ thermometer | GATT notify      | local name `Inkbird@IBT-24SPH`     | temperature × 4 probes, battery                                     |
 | `INT-11P-B`             | Connected BBQ probe   | GATT poll          | local name `int-11p-b`             | probe temperature, ambient temperature, probe battery, case battery |
 | `iBBQ-1`                | BBQ probe (1 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 1                                                     |
 | `iBBQ-2`                | BBQ probe (2 channel) | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 2                                                     |

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -24,13 +24,14 @@ from bluetooth_data_tools import (
     monotonic_time_coarse,
     short_address,
 )
-from bluetooth_sensor_state_data import BluetoothData, SensorUpdate
+from bluetooth_sensor_state_data import BluetoothData
 from sensor_state_data import SensorLibrary, Units
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable
 
     from bleak import BleakGATTCharacteristic, BLEDevice
+    from bluetooth_sensor_state_data import SensorUpdate
     from habluetooth import BluetoothServiceInfoBleak
 
 
@@ -53,6 +54,7 @@ class Model(StrEnum):
     IAM_T2 = "IAM-T2"
     IHT_2PB = "IHT-2PB"
     INT_11P_B = "INT-11P-B"
+    IBT_4WB = "IBT-4WB"
 
 
 class ModelType(Enum):
@@ -68,7 +70,7 @@ class ModelInfo:
     model_type: ModelType
     local_name: str | None
     message_length: int
-    unpacker: Callable[[bytes], tuple[int, ...]]
+    unpacker: Callable[[bytes], tuple[int, ...]] | None
     service_uuid: UUID | None
     characteristic_uuid: UUID | None
     notify_uuid: UUID | None
@@ -93,6 +95,28 @@ EIGHTEEN_BYTE_SENSOR_DATA_CHARACTERISTIC_UUID = UUID(
 )
 NINE_BYTE_SENSOR_DATA_CHARACTERISTIC_UUID = UUID("0000fff2-0000-1000-8000-00805f9b34fb")
 IAM_T1_CHARACTERISTIC_UUID = UUID("0000fff4-0000-1000-8000-00805f9b34fb")
+IBT_4WB_SERVICE_UUID = UUID("0000ff00-0000-1000-8000-00805f9b34fb")
+IBT_4WB_NOTIFY_UUID = UUID("0000ff01-0000-1000-8000-00805f9b34fb")
+IBT_4WB_WRITE_UUID = UUID("0000ff02-0000-1000-8000-00805f9b34fb")
+IBT_4WB_ACK_UUID = UUID("0000ff03-0000-1000-8000-00805f9b34fb")
+IBT_4WB_BATTERY_UUID = UUID("00002a19-0000-1000-8000-00805f9b34fb")
+IBT_4WB_NO_PROBE = 0x7FFE
+IBT_4WB_DATA_LENGTH = 10
+
+# Commands are 7-byte payloads written to FF02; the device ACKs on FF03.
+# Byte 0: command type
+# Byte 1: parameter (or probe bitmask for calibration)
+# Bytes 2-5: additional parameters
+# Byte 6: 0x00 terminator
+IBT_4WB_CMD_UNIT_C = b"\x03\x43\x00\x00\x00\x00\x00"   # display °C
+IBT_4WB_CMD_UNIT_F = b"\x03\x46\x00\x00\x00\x00\x00"   # display °F
+IBT_4WB_CMD_SOUND_ON = b"\x0b\x5a\x00\x00\x00\x00\x00"  # un-mute / beeper on
+IBT_4WB_CMD_SOUND_OFF = b"\x0b\x11\x00\x00\x00\x00\x00" # mute / beeper off
+# State-sync: asks the device to ACK with current calibration values.
+# Also serves as keepalive -- the Inkbird app sends this after every write.
+IBT_4WB_CMD_STATE_SYNC = b"\x0a\x0f\x00\x00\x00\x00\x00"
+IBT_4WB_KEEPALIVE_INTERVAL = 3  # seconds between keepalive state-sync writes
+IBT_4WB_CALIBRATION_MAX_C = 5.0  # maximum calibration offset in °C
 
 INKBIRD_UNPACK = struct.Struct("<hH").unpack
 
@@ -376,6 +400,18 @@ MODEL_INFO = {
         use_local_name_for_device=False,
         parse_adv=False,
     ),
+    Model.IBT_4WB: ModelInfo(
+        name="IBT-4WB",
+        model_type=ModelType.SENSOR,
+        local_name="inkbird@ibt-24sph",
+        message_length=IBT_4WB_DATA_LENGTH,
+        unpacker=None,
+        service_uuid=IBT_4WB_SERVICE_UUID,
+        characteristic_uuid=None,
+        notify_uuid=IBT_4WB_NOTIFY_UUID,
+        use_local_name_for_device=False,
+        parse_adv=False,
+    ),
 }
 
 INKBIRD_NAMES = {
@@ -567,6 +603,8 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         # Last time we got a full update from ADV data
         self._last_full_update = 0.0
         self._notify_task: asyncio.Task[None] | None = None
+        self._ibt_4wb_client: BleakClientWithServiceCache | None = None
+        self._ibt_4wb_write_lock: asyncio.Lock = asyncio.Lock()
         self._running = True
         self._device_data = device_data.copy() if device_data else {}
         self._update_callback = update_callback
@@ -618,13 +656,24 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         dev_info = MODEL_INFO[self._device_type]
         notify_uuid = dev_info.notify_uuid
         loop = asyncio.get_running_loop()
-        disconnect_future = loop.create_future()
+        disconnect_future: asyncio.Future[None] = loop.create_future()
 
         def _resolve_disconnect_callback(_: BleakClientWithServiceCache) -> None:
             if not disconnect_future.done():
                 disconnect_future.set_result(None)
 
         client.set_disconnected_callback(_resolve_disconnect_callback)
+        if self._device_type == Model.IBT_4WB:
+            # Read battery before subscribing to notifications so the value is
+            # stored and included in the very first temperature SensorUpdate.
+            try:
+                bat_data = await client.read_gatt_char(IBT_4WB_BATTERY_UUID)
+                if bat_data:
+                    self.update_predefined_sensor(
+                        SensorLibrary.BATTERY__PERCENTAGE, int(bat_data[0])
+                    )
+            except BleakError as err:
+                _LOGGER.debug("IBT-4WB battery read failed: %s", err)
         await client.start_notify(notify_uuid, self._notify_callback)
         for char_uuid, payload in dev_info.notify_init_writes:
             # Some devices (e.g. IHT-2PB) only start streaming after an
@@ -633,7 +682,80 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             # notifying, so a write error must not abort the session.
             with contextlib.suppress(BleakError):
                 await client.write_gatt_char(char_uuid, payload, response=False)
-        await disconnect_future  # wait for disconnect
+        if self._device_type == Model.IBT_4WB:
+            self._ibt_4wb_client = client
+            keepalive_task = asyncio.create_task(
+                self._async_ibt_4wb_keepalive(client, disconnect_future)
+            )
+            try:
+                await disconnect_future
+            finally:
+                self._ibt_4wb_client = None
+                keepalive_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await keepalive_task
+        else:
+            await disconnect_future  # wait for disconnect
+
+    async def _async_ibt_4wb_keepalive(
+        self,
+        client: BleakClientWithServiceCache,
+        disconnect_future: asyncio.Future[None],
+    ) -> None:
+        """Send periodic state-sync writes to FF02 to maintain the BLE link.
+
+        The Inkbird app uses the 0x0A state-sync command as its heartbeat.
+        The device ACKs on FF03 with the current calibration values.
+        """
+        while not disconnect_future.done():
+            try:
+                async with self._ibt_4wb_write_lock:
+                    await client.write_gatt_char(
+                        IBT_4WB_WRITE_UUID, IBT_4WB_CMD_STATE_SYNC, response=False
+                    )
+            except BleakError as err:
+                _LOGGER.debug("IBT-4WB keepalive write failed: %s", err)
+                break
+            await asyncio.sleep(IBT_4WB_KEEPALIVE_INTERVAL)
+
+    def _notify_ibt_4wb(
+        self, sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Dispatch an IBT-4WB notification to the temperature update handler."""
+        if len(data) == IBT_4WB_DATA_LENGTH:
+            self._update_ibt_4wb_notify(bytes(data))
+
+    def _update_ibt_4wb_notify(self, data: bytes) -> None:
+        """Update IBT-4WB temperature sensors from a 10-byte notification payload.
+
+        The device broadcasts temperatures as Fahrenheit * 10 (signed int16 LE).
+        0x7FFE means no probe connected.
+        """
+        for idx in range(4):
+            # A single signed read suffices: 0x7FFE (32766) is positive as
+            # both signed and unsigned int16, so the sentinel check is identical.
+            raw = struct.unpack_from("<h", data, idx * 2)[0]
+            num = idx + 1
+            if raw == IBT_4WB_NO_PROBE:
+                self.update_predefined_sensor(
+                    SensorLibrary.TEMPERATURE__CELSIUS,
+                    None,
+                    key=f"temperature_probe_{num}",
+                    name=f"Temperature Probe {num}",
+                )
+                continue
+            temp_f = raw / 10.0
+            temp_c = round((temp_f - 32) * 5 / 9, 1)
+            self.update_predefined_sensor(
+                SensorLibrary.TEMPERATURE__CELSIUS,
+                temp_c,
+                key=f"temperature_probe_{num}",
+                name=f"Temperature Probe {num}",
+            )
+        if self._update_callback is None:
+            _LOGGER.debug("IBT-4WB: update_callback not set, dropping update")
+            return
+        self._update_callback(self._finish_update())
 
     def _notify_callback(
         self, sender: BleakGATTCharacteristic, data: bytearray
@@ -877,6 +999,9 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
     def _start_update(self, service_info: BluetoothServiceInfoBleak) -> None:
         """Update from BLE advertisement data."""
         _LOGGER.debug("Parsing inkbird BLE advertisement data: %s", service_info)
+        lower_name = service_info.name.lower()
+        if self._device_type is None:
+            self._device_type = INKBIRD_NAMES.get(lower_name)
         if not (manufacturer_data := service_info.manufacturer_data):
             self._set_name_and_manufacturer(service_info)
             return
@@ -1281,6 +1406,111 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             name="Case Battery",
         )
 
+    # ------------------------------------------------------------------
+    # IBT-4WB write commands
+    # ------------------------------------------------------------------
+
+    async def async_ibt_4wb_set_temperature_unit(
+        self, ble_device: BLEDevice, celsius: bool
+    ) -> None:
+        """Set the temperature display unit on the IBT-4WB.
+
+        Note: the device always transmits temperatures internally as
+        Fahrenheit * 10; this command only changes what the device's
+        own screen displays.
+        """
+        cmd = IBT_4WB_CMD_UNIT_C if celsius else IBT_4WB_CMD_UNIT_F
+        await self._async_ibt_4wb_write(ble_device, cmd)
+
+    async def async_ibt_4wb_set_sound_enabled(
+        self, ble_device: BLEDevice, enabled: bool
+    ) -> None:
+        """Enable or disable the IBT-4WB beeper / alarm sound."""
+        cmd = IBT_4WB_CMD_SOUND_ON if enabled else IBT_4WB_CMD_SOUND_OFF
+        await self._async_ibt_4wb_write(ble_device, cmd)
+
+    async def async_ibt_4wb_set_brightness(
+        self, ble_device: BLEDevice, level: int
+    ) -> None:
+        """Set the IBT-4WB screen brightness (0-100 %).
+
+        The device accepts values 0-100 decimal in byte 1.
+        In practice the Inkbird app clips the minimum to 4.
+        """
+        level = max(0, min(100, level))
+        cmd = bytes([0x05, level, 0x00, 0x00, 0x00, 0x00, 0x00])
+        await self._async_ibt_4wb_write(ble_device, cmd)
+
+    async def async_ibt_4wb_set_calibration(
+        self,
+        ble_device: BLEDevice,
+        offsets_celsius: dict[int, float],
+    ) -> None:
+        """Set per-probe temperature calibration offsets (in °C).
+
+        ``offsets_celsius`` maps probe number (1-4) to offset in °C.
+        Offsets are converted to the device's native 0.1 °F unit using
+        ``int(celsius * 9/5 * 10)`` (truncation toward zero, matching
+        the Inkbird app's behaviour).
+
+        Example::
+
+            await data.async_ibt_4wb_set_calibration(
+                ble_device, {1: -0.1, 2: 0.0, 3: 0.5}
+            )
+        """
+        if not offsets_celsius:
+            return
+        probe_to_bit = {1: 0x01, 2: 0x02, 3: 0x04, 4: 0x08}
+        mask = 0
+        cal: list[int] = [0, 0, 0, 0]  # indices 0-3 -> probes 1-4
+        for probe_num, offset_c in offsets_celsius.items():
+            if probe_num not in probe_to_bit:
+                msg = f"probe_num must be 1-4, got {probe_num!r}"
+                raise ValueError(msg)
+            lo, hi = -IBT_4WB_CALIBRATION_MAX_C, IBT_4WB_CALIBRATION_MAX_C
+            if not (lo <= offset_c <= hi):
+                msg = (
+                    f"offset_c must be in"
+                    f" -{IBT_4WB_CALIBRATION_MAX_C}..+{IBT_4WB_CALIBRATION_MAX_C} C,"
+                    f" got {offset_c!r}"
+                )
+                raise ValueError(msg)
+            mask |= probe_to_bit[probe_num]
+            # Convert °C offset -> 0.1 °F units, truncate toward zero
+            raw = int(offset_c * 9 / 5 * 10)
+            cal[probe_num - 1] = raw & 0xFF  # to unsigned byte
+        cmd = bytes([0x09, mask, cal[0], cal[1], cal[2], cal[3], 0x00])
+        await self._async_ibt_4wb_write(ble_device, cmd)
+
+    async def _async_ibt_4wb_write(
+        self, ble_device: BLEDevice, cmd: bytes
+    ) -> None:
+        """Write a command to FF02 then send the state-sync to get an ACK.
+
+        Reuses the persistent keepalive connection if it is still active to
+        avoid triggering an ``InProgress`` error from BlueZ when a second
+        connection attempt is made while the keepalive loop is running.
+        """
+        if self._ibt_4wb_client and self._ibt_4wb_client.is_connected:
+            async with self._ibt_4wb_write_lock:
+                await self._ibt_4wb_client.write_gatt_char(
+                    IBT_4WB_WRITE_UUID, cmd, response=True
+                )
+                await self._ibt_4wb_client.write_gatt_char(
+                    IBT_4WB_WRITE_UUID, IBT_4WB_CMD_STATE_SYNC, response=True
+                )
+            return
+
+        async def _action(client: BleakClientWithServiceCache) -> bytes | None:
+            await client.write_gatt_char(IBT_4WB_WRITE_UUID, cmd, response=True)
+            await client.write_gatt_char(
+                IBT_4WB_WRITE_UUID, IBT_4WB_CMD_STATE_SYNC, response=True
+            )
+            return None
+
+        await async_connect_action(ble_device, _action)
+
     _device_type_dispatch: ClassVar[
         dict[Model, Callable[[INKBIRDBluetoothDeviceData, bytes, int], None]]
     ]
@@ -1308,4 +1538,5 @@ INKBIRDBluetoothDeviceData._device_type_dispatch = {  # noqa: SLF001
 INKBIRDBluetoothDeviceData._notify_dispatch = {  # noqa: SLF001
     Model.IAM_T1: INKBIRDBluetoothDeviceData._notify_iam_t1,  # noqa: SLF001
     Model.IHT_2PB: INKBIRDBluetoothDeviceData._notify_iht_2pb,  # noqa: SLF001
+    Model.IBT_4WB: INKBIRDBluetoothDeviceData._notify_ibt_4wb,  # noqa: SLF001
 }

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -108,10 +108,10 @@ IBT_4WB_DATA_LENGTH = 10
 # Byte 1: parameter (or probe bitmask for calibration)
 # Bytes 2-5: additional parameters
 # Byte 6: 0x00 terminator
-IBT_4WB_CMD_UNIT_C = b"\x03\x43\x00\x00\x00\x00\x00"   # display °C
-IBT_4WB_CMD_UNIT_F = b"\x03\x46\x00\x00\x00\x00\x00"   # display °F
+IBT_4WB_CMD_UNIT_C = b"\x03\x43\x00\x00\x00\x00\x00"  # display °C
+IBT_4WB_CMD_UNIT_F = b"\x03\x46\x00\x00\x00\x00\x00"  # display °F
 IBT_4WB_CMD_SOUND_ON = b"\x0b\x5a\x00\x00\x00\x00\x00"  # un-mute / beeper on
-IBT_4WB_CMD_SOUND_OFF = b"\x0b\x11\x00\x00\x00\x00\x00" # mute / beeper off
+IBT_4WB_CMD_SOUND_OFF = b"\x0b\x11\x00\x00\x00\x00\x00"  # mute / beeper off
 # State-sync: asks the device to ACK with current calibration values.
 # Also serves as keepalive -- the Inkbird app sends this after every write.
 IBT_4WB_CMD_STATE_SYNC = b"\x0a\x0f\x00\x00\x00\x00\x00"
@@ -719,7 +719,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
             await asyncio.sleep(IBT_4WB_KEEPALIVE_INTERVAL)
 
     def _notify_ibt_4wb(
-        self, sender: BleakGATTCharacteristic, data: bytearray
+        self, _sender: BleakGATTCharacteristic, data: bytearray
     ) -> None:
         """Dispatch an IBT-4WB notification to the temperature update handler."""
         if len(data) == IBT_4WB_DATA_LENGTH:
@@ -1483,9 +1483,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         cmd = bytes([0x09, mask, cal[0], cal[1], cal[2], cal[3], 0x00])
         await self._async_ibt_4wb_write(ble_device, cmd)
 
-    async def _async_ibt_4wb_write(
-        self, ble_device: BLEDevice, cmd: bytes
-    ) -> None:
+    async def _async_ibt_4wb_write(self, ble_device: BLEDevice, cmd: bytes) -> None:
         """Write a command to FF02 then send the state-sync to get an ACK.
 
         Reuses the persistent keepalive connection if it is still active to

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -88,6 +88,13 @@ class ModelInfo:
     # See https://github.com/Bluetooth-Devices/inkbird-ble/issues/116
     supports_polling: bool = True
 
+    def unpack(self, data: bytes) -> tuple[int, ...]:
+        """Unpack ``data`` with this model's unpacker."""
+        if self.unpacker is None:  # pragma: no cover
+            msg = f"{self.name} has no unpacker"
+            raise TypeError(msg)
+        return self.unpacker(data)
+
 
 INKBIRD_SERVICE_UUID = UUID("0000fff0-0000-1000-8000-00805f9b34fb")
 EIGHTEEN_BYTE_SENSOR_DATA_CHARACTERISTIC_UUID = UUID(
@@ -1149,7 +1156,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         if TYPE_CHECKING:
             assert self._device_type is not None
         xvalue = data[10:]
-        for idx, temp in enumerate(MODEL_INFO[self._device_type].unpacker(xvalue)):
+        for idx, temp in enumerate(MODEL_INFO[self._device_type].unpack(xvalue)):
             if temp in BBQ_PROBE_NOT_CONNECTED:
                 # Probe not plugged in; skip it instead of reporting 6553.5°C.
                 continue
@@ -1170,7 +1177,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
     ) -> None:
         if TYPE_CHECKING:
             assert self._device_type is not None
-        temp, hum = MODEL_INFO[self._device_type].unpacker(temp_hum_bytes)
+        temp, hum = MODEL_INFO[self._device_type].unpack(temp_hum_bytes)
         # Only some models report humidity: IBS-TH always, IBS-TH2 when non-zero.
         reports_humidity = self._device_type == Model.IBS_TH or (
             self._device_type == Model.IBS_TH2 and hum != 0
@@ -1304,7 +1311,7 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         """Update the sensor values for a 18 byte model."""
         if TYPE_CHECKING:
             assert self._device_type is not None
-        temp, hum = MODEL_INFO[self._device_type].unpacker(temp_hum_bytes)
+        temp, hum = MODEL_INFO[self._device_type].unpack(temp_hum_bytes)
         humidity = hum / 10
         if not self._is_humidity_plausible(humidity):
             return

--- a/tests/test_ibt_4wb.py
+++ b/tests/test_ibt_4wb.py
@@ -1,0 +1,837 @@
+"""Tests for the INKBIRD IBT-4WB 4-probe BBQ thermometer parser."""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+from bluetooth_data_tools import monotonic_time_coarse
+from habluetooth import BluetoothServiceInfoBleak
+from sensor_state_data import DeviceKey
+
+from inkbird_ble.parser import (
+    IBT_4WB_CMD_STATE_SYNC,
+    IBT_4WB_DATA_LENGTH,
+    IBT_4WB_NO_PROBE,
+    IBT_4WB_WRITE_UUID,
+    INKBIRDBluetoothDeviceData,
+    Model,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from bluetooth_sensor_state_data import SensorUpdate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+IBT_4WB_ADDRESS = "40:79:12:1A:B4:56"
+IBT_4WB_SHORT_ADDRESS = "B456"
+IBT_4WB_NAME = "Inkbird@IBT-24SPH"
+
+
+def make_ibt_4wb_service_info(
+    rssi: int = -60,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> BluetoothServiceInfoBleak:
+    """Return a BluetoothServiceInfoBleak for the IBT-4WB."""
+    return BluetoothServiceInfoBleak(
+        name=IBT_4WB_NAME,
+        manufacturer_data=manufacturer_data or {},
+        service_uuids=["0000ff00-0000-1000-8000-00805f9b34fb"],
+        address=IBT_4WB_ADDRESS,
+        rssi=rssi,
+        service_data={},
+        source="local",
+        device=BLEDevice(
+            name=IBT_4WB_NAME,
+            address=IBT_4WB_ADDRESS,
+            details={},
+            rssi=rssi,
+        ),
+        time=monotonic_time_coarse(),
+        advertisement=None,
+        connectable=True,
+        tx_power=0,
+        raw=None,
+    )
+
+
+def make_notify_payload(
+    probe1_f10: int | None = None,
+    probe2_f10: int | None = None,
+    probe3_f10: int | None = None,
+    probe4_f10: int | None = None,
+) -> bytes:
+    """Build a 10-byte IBT-4WB notification payload.
+
+    Each argument is the temperature in Fahrenheit * 10 (signed int16), or
+    None to encode the no-probe sentinel (0x7FFE).
+    """
+    NO_PROBE = IBT_4WB_NO_PROBE  # 0x7FFE
+
+    def encode(val: int | None) -> bytes:
+        if val is None:
+            return struct.pack("<H", NO_PROBE)
+        return struct.pack("<h", val)
+
+    return (
+        encode(probe1_f10)
+        + encode(probe2_f10)
+        + encode(probe3_f10)
+        + encode(probe4_f10)
+        + b"\x00\x00"
+    )
+
+
+def f_to_c(fahrenheit_x10: int) -> float:
+    """Convert Fahrenheit*10 raw int to rounded Celsius (1 decimal)."""
+    return round((fahrenheit_x10 / 10.0 - 32) * 5 / 9, 1)
+
+
+# ---------------------------------------------------------------------------
+# Detection tests
+# ---------------------------------------------------------------------------
+
+
+def test_ibt_4wb_supported_from_local_name() -> None:
+    """IBT-4WB is detected from the 'Inkbird@IBT-*' local name prefix."""
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = make_ibt_4wb_service_info()
+    assert parser.supported(service_info) is True
+    assert parser.device_type == Model.IBT_4WB
+
+
+def test_ibt_4wb_uses_notify() -> None:
+    """IBT-4WB should be flagged as a notify-based device."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    assert parser.uses_notify is True
+
+
+def test_ibt_4wb_does_not_need_poll() -> None:
+    """Notify-based IBT-4WB never requests polling."""
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+    assert parser.poll_needed(service_info, None) is False
+
+
+# ---------------------------------------------------------------------------
+# Temperature conversion tests
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_conversion_typical() -> None:
+    """68 °F -> 20.0 °C; 75 °F -> 23.9 °C."""
+    assert f_to_c(680) == 20.0
+    assert f_to_c(750) == 23.9
+
+
+def test_temperature_conversion_boiling() -> None:
+    """212 °F -> 100.0 °C."""
+    assert f_to_c(2120) == 100.0
+
+
+def test_temperature_conversion_freezing() -> None:
+    """32 °F -> 0.0 °C."""
+    assert f_to_c(320) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Notification callback tests (synchronous, no BLE connection required)
+# ---------------------------------------------------------------------------
+
+
+def test_ibt_4wb_notify_two_probes_active() -> None:
+    """Notification with 2 active probes and 2 absent probes fires correct update."""
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    def _data_cb(data: dict[str, Any]) -> None:
+        pass
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, _data_cb)
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    # Build and inject a 10-byte notification (probes 1+2 active, 3+4 absent)
+    payload = make_notify_payload(
+        probe1_f10=680,  # 68.0 °F = 20.0 °C
+        probe2_f10=750,  # 75.0 °F = 23.9 °C
+        probe3_f10=None,
+        probe4_f10=None,
+    )
+    assert len(payload) == IBT_4WB_DATA_LENGTH
+
+    parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001
+
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].native_value == 20.0
+    assert values[DeviceKey("temperature_probe_2", None)].native_value == 23.9
+    # Absent probes are included in the update with native_value=None so that
+    # HA marks them as unavailable rather than showing a stale reading.
+    assert values[DeviceKey("temperature_probe_3", None)].native_value is None
+    assert values[DeviceKey("temperature_probe_4", None)].native_value is None
+
+
+def test_ibt_4wb_notify_all_probes_active() -> None:
+    """All 4 probes active -> 4 temperature entities."""
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(
+        probe1_f10=680,   # 20.0 °C
+        probe2_f10=750,   # 23.9 °C
+        probe3_f10=2120,  # 100.0 °C
+        probe4_f10=320,   # 0.0 °C
+    )
+    parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001
+
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].native_value == 20.0
+    assert values[DeviceKey("temperature_probe_2", None)].native_value == 23.9
+    assert values[DeviceKey("temperature_probe_3", None)].native_value == 100.0
+    assert values[DeviceKey("temperature_probe_4", None)].native_value == 0.0
+
+
+def test_ibt_4wb_notify_all_no_probe() -> None:
+    """All probes absent -> every probe sensor reports native_value=None."""
+    updates: list[SensorUpdate] = []
+
+    def _update_cb(update: SensorUpdate) -> None:
+        updates.append(update)
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload()  # all None -> all 0x7FFE
+    parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001
+
+    assert len(updates) == 1
+    values = updates[0].entity_values
+    # Each absent probe is included in the update with native_value=None so
+    # HA can mark it unavailable instead of holding a stale reading.
+    for probe in range(1, 5):
+        key = DeviceKey(f"temperature_probe_{probe}", None)
+        assert values[key].native_value is None
+
+
+def test_ibt_4wb_notify_wrong_length_ignored() -> None:
+    """Notification payloads that are not exactly 10 bytes are silently dropped."""
+    updates: list[SensorUpdate] = []
+
+    def _update_cb(update: SensorUpdate) -> None:
+        updates.append(update)
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    parser._notify_callback(MagicMock(), bytearray(5))  # noqa: SLF001
+
+    assert len(updates) == 0
+
+
+def test_ibt_4wb_entity_names() -> None:
+    """Temperature probe entities carry human-readable names."""
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680, probe2_f10=750)
+    parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001
+
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].name == "Temperature Probe 1"
+    assert values[DeviceKey("temperature_probe_2", None)].name == "Temperature Probe 2"
+
+
+# ---------------------------------------------------------------------------
+# Async notify integration tests (mocked BLE connection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_async_start_notify_temperatures_and_battery() -> None:
+    """async_start with mocked BLE: temperatures and battery appear in update."""
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info(rssi=-44)
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680, probe2_f10=750)
+    disconnect_mock = AsyncMock()
+    read_gatt_char_mock = AsyncMock(return_value=b"\x39")  # 57 %
+    write_gatt_char_mock = AsyncMock()
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=disconnect_mock,
+        read_gatt_char=read_gatt_char_mock,
+        write_gatt_char=write_gatt_char_mock,
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-44),
+        )
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].native_value == 20.0
+    assert values[DeviceKey("temperature_probe_2", None)].native_value == 23.9
+    assert values[DeviceKey("battery", None)].native_value == 57
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_battery_read_failure_is_silent() -> None:
+    """BleakError on battery read does not crash and temperatures still arrive."""
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+    disconnect_mock = AsyncMock()
+    read_gatt_char_mock = AsyncMock(side_effect=BleakError("characteristic not found"))
+    write_gatt_char_mock = AsyncMock()
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=disconnect_mock,
+        read_gatt_char=read_gatt_char_mock,
+        write_gatt_char=write_gatt_char_mock,
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].native_value == 20.0
+    assert DeviceKey("battery", None) not in values
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_keepalive_writes_ff02() -> None:
+    """Keepalive writes go to FF02 with the correct payload."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, MagicMock(), MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+    disconnect_mock = AsyncMock()
+    read_gatt_char_mock = AsyncMock(return_value=b"\x39")
+    write_gatt_char_mock = AsyncMock()
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=disconnect_mock,
+        read_gatt_char=read_gatt_char_mock,
+        write_gatt_char=write_gatt_char_mock,
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        # Two yields: first lets the notify task run and create the keepalive task;
+        # second lets the keepalive task execute its initial write before sleeping.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    # At least one keepalive write should have been issued to FF02
+    assert write_gatt_char_mock.call_count >= 1
+    call_args = write_gatt_char_mock.call_args_list[0]
+    assert call_args.args[0] == IBT_4WB_WRITE_UUID
+    assert call_args.args[1] == IBT_4WB_CMD_STATE_SYNC
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_keepalive_failure_is_silent() -> None:
+    """BleakError on keepalive write is logged and the loop exits cleanly."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, MagicMock(), MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+    disconnect_mock = AsyncMock()
+    read_gatt_char_mock = AsyncMock(return_value=b"\x39")
+    write_gatt_char_mock = AsyncMock(side_effect=BleakError("disconnected"))
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=disconnect_mock,
+        read_gatt_char=read_gatt_char_mock,
+        write_gatt_char=write_gatt_char_mock,
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        # First yield lets the notify task run and schedule the keepalive task;
+        # second yield lets the keepalive task execute and hit the BleakError.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    # Keepalive failure should not raise -- just exit the loop.
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_retries_on_start_notify_error() -> None:
+    """When start_notify raises BleakError, async_connect_action retries once.
+
+    The retry happens within the same task iteration (no 5-second sleep) because
+    async_connect_action loops up to two times internally.
+    """
+    last_update: SensorUpdate | None = None
+
+    def _update_cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+    start_notify_calls = 0
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        nonlocal start_notify_calls
+        start_notify_calls += 1
+        if start_notify_calls == 1:
+            msg = "service discovery failed"
+            raise BleakError(msg)
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=AsyncMock(),
+        read_gatt_char=AsyncMock(return_value=b"\x39"),
+        write_gatt_char=AsyncMock(),
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    # Both attempts happened; the second one delivered temperature data.
+    assert start_notify_calls >= 2
+    assert last_update is not None
+    values = last_update.entity_values
+    assert values[DeviceKey("temperature_probe_1", None)].native_value == 20.0
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_client_set_and_cleared() -> None:
+    """_ibt_4wb_client is stored while connected and cleared in the finally block."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, MagicMock(), MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=AsyncMock(),
+        read_gatt_char=AsyncMock(return_value=b"\x39"),
+        write_gatt_char=AsyncMock(),
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        await asyncio.sleep(0)
+        # Client is stored while the keepalive loop is running.
+        client_ref = parser._ibt_4wb_client  # noqa: SLF001
+        assert client_ref is not None
+        await parser.async_stop()
+        # Client reference is cleared in the finally block after disconnect.
+        assert parser._ibt_4wb_client is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Write method tests
+# ---------------------------------------------------------------------------
+
+
+def _make_write_client() -> MagicMock:
+    """Return a mock BLE client suitable for write-command tests."""
+    return MagicMock(
+        write_gatt_char=AsyncMock(),
+        disconnect=AsyncMock(),
+        clear_cache=AsyncMock(),
+    )
+
+
+def _ble_device() -> BLEDevice:
+    return BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60)
+
+
+@pytest.mark.asyncio
+async def test_write_reuses_active_keepalive_client() -> None:
+    """_async_ibt_4wb_write uses _ibt_4wb_client directly when it is connected.
+
+    This avoids the ``org.bluez.Error.InProgress`` error that occurs when a
+    second connection is opened while the keepalive loop already holds the link.
+    """
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = MagicMock(
+        is_connected=True,
+        write_gatt_char=AsyncMock(),
+    )
+    parser._ibt_4wb_client = mock_client  # noqa: SLF001
+
+    with patch("inkbird_ble.parser.establish_connection") as mock_establish:
+        await parser.async_ibt_4wb_set_sound_enabled(_ble_device(), enabled=True)
+        # establish_connection must NOT have been called -- reused existing client.
+        mock_establish.assert_not_called()
+
+    # The command and the state-sync were written on the existing client.
+    assert mock_client.write_gatt_char.call_count == 2
+    cmd_write, sync_write = mock_client.write_gatt_char.call_args_list
+    assert cmd_write.args[1] == b"\x0b\x5a\x00\x00\x00\x00\x00"  # SOUND_ON
+    assert sync_write.args[1] == IBT_4WB_CMD_STATE_SYNC
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_unit_celsius() -> None:
+    """async_ibt_4wb_set_temperature_unit(True) writes the degrees-C command."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_temperature_unit(_ble_device(), celsius=True)
+
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1] == b"\x03\x43\x00\x00\x00\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_unit_fahrenheit() -> None:
+    """async_ibt_4wb_set_temperature_unit(False) writes the degrees-F command."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_temperature_unit(_ble_device(), celsius=False)
+
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1] == b"\x03\x46\x00\x00\x00\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_set_sound_enabled() -> None:
+    """Sound-on command byte sequence matches captured traffic."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_sound_enabled(_ble_device(), enabled=True)
+
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1] == b"\x0b\x5a\x00\x00\x00\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_set_sound_disabled() -> None:
+    """Mute command byte sequence matches captured traffic."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_sound_enabled(_ble_device(), enabled=False)
+
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1] == b"\x0b\x11\x00\x00\x00\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_100() -> None:
+    """100 percent brightness gives byte 1 = 0x64."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_brightness(_ble_device(), 100)
+
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1] == b"\x05\x64\x00\x00\x00\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_clamps_low() -> None:
+    """Values below 0 are clamped to 0."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_brightness(_ble_device(), -10)
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1][1] == 0
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_clamps_high() -> None:
+    """Values above 100 are clamped to 100."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_brightness(_ble_device(), 200)
+    first_write = mock_client.write_gatt_char.call_args_list[0]
+    assert first_write.args[1][1] == 100
+
+
+@pytest.mark.asyncio
+async def test_write_always_sends_state_sync() -> None:
+    """Every write command is followed by the state-sync packet."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_sound_enabled(_ble_device(), enabled=True)
+
+    assert mock_client.write_gatt_char.call_count == 2
+    second_write = mock_client.write_gatt_char.call_args_list[1]
+    assert second_write.args[1] == IBT_4WB_CMD_STATE_SYNC
+
+
+@pytest.mark.asyncio
+async def test_calibration_probe1_minus_0_1c() -> None:
+    """Minus 0.1 C calibration on probe 1: int(-0.1*9/5*10) = -1 = 0xFF."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {1: -0.1})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[0] == 0x09          # calibration command
+    assert cmd[1] == 0x01          # probe 1 bitmask
+    assert cmd[2] == 0xFF          # -1 as unsigned byte
+    assert cmd[3] == cmd[4] == cmd[5] == 0x00
+
+
+@pytest.mark.asyncio
+async def test_calibration_probe2_plus_0_1c() -> None:
+    """Plus 0.1 C calibration on probe 2: int(+0.1*9/5*10) = +1 = 0x01."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {2: 0.1})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[1] == 0x02          # probe 2 bitmask
+    assert cmd[3] == 0x01          # +1
+
+
+@pytest.mark.asyncio
+async def test_calibration_probe4_plus_1c() -> None:
+    """Plus 1 C calibration on probe 4: int(+1*9/5*10) = +18 = 0x12."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {4: 1.0})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[1] == 0x08          # probe 4 bitmask
+    assert cmd[5] == 0x12          # +18
+
+
+@pytest.mark.asyncio
+async def test_calibration_probe4_minus_1c() -> None:
+    """Minus 1 C: int(-18) = -18 = 0xEE."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {4: -1.0})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[5] == 0xEE          # -18 as unsigned byte
+
+
+@pytest.mark.asyncio
+async def test_calibration_probe3_minus_0_2c() -> None:
+    """Minus 0.2 C: int(-3.6) = -3 = 0xFD (matches captured traffic)."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {3: -0.2})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[1] == 0x04          # probe 3 bitmask
+    assert cmd[4] == 0xFD          # -3 as unsigned byte
+
+
+@pytest.mark.asyncio
+async def test_calibration_multi_probe() -> None:
+    """Setting probes 1 and 3 together produces the combined bitmask."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    mock_client = _make_write_client()
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {1: 0.0, 3: 0.0})
+
+    cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
+    assert cmd[1] == 0x05          # 0x01 | 0x04
+
+
+def test_calibration_invalid_probe_raises() -> None:
+    """Probe numbers outside 1-4 raise ValueError immediately."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    with pytest.raises(ValueError, match="probe_num"):
+        asyncio.run(parser.async_ibt_4wb_set_calibration(_ble_device(), {5: 0.0}))
+
+
+def test_calibration_out_of_range_raises() -> None:
+    """Offsets outside ±5.0 °C raise ValueError."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    with pytest.raises(ValueError, match="offset_c must be in"):
+        asyncio.run(parser.async_ibt_4wb_set_calibration(_ble_device(), {1: 5.1}))
+    with pytest.raises(ValueError, match="offset_c must be in"):
+        asyncio.run(parser.async_ibt_4wb_set_calibration(_ble_device(), {1: -5.1}))
+
+
+@pytest.mark.asyncio
+async def test_calibration_empty_dict_is_noop() -> None:
+    """An empty offsets dict returns without writing anything."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB)
+    with patch("inkbird_ble.parser.establish_connection") as mock_establish:
+        await parser.async_ibt_4wb_set_calibration(_ble_device(), {})
+        mock_establish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Edge-case / branch-coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_notify_callback_ignored_when_not_running() -> None:
+    """_notify_callback returns immediately when _running is False (line 544-545)."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, MagicMock(), MagicMock())
+    # _running starts True in __init__; simulate async_stop() having been called.
+    parser._running = False  # noqa: SLF001
+    sender = MagicMock()
+    payload = bytearray(make_notify_payload(probe1_f10=680))
+    # Should silently return without calling _update_ibt_4wb_notify.
+    parser._notify_callback(sender, payload)  # noqa: SLF001
+
+
+def test_notify_callback_ignored_for_unknown_device_type() -> None:
+    """_notify_callback returns early for non-IBT_4WB, non-IAM_T1 device types.
+
+    Constructs a parser with a model that is neither IBT_4WB nor IAM_T1 and
+    injects a direct call to the callback so the ``device_type != IAM_T1``
+    guard branch is exercised.
+    """
+    # IBS_TH uses passive advertisement data, not notifications; calling
+    # _notify_callback directly exercises the ``device_type != IAM_T1`` return.
+    parser = INKBIRDBluetoothDeviceData(Model.IBS_TH, {}, MagicMock(), MagicMock())
+    sender = MagicMock()
+    # Any data is fine — should return before any processing.
+    parser._notify_callback(sender, bytearray(10))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_ibt_4wb_battery_read_empty_skips_sensor() -> None:
+    """Battery sensor is skipped when read_gatt_char returns empty bytes.
+
+    Covers the ``if bat_data:`` FALSE path so the notification subscription
+    still proceeds even when the battery characteristic returns no data.
+    """
+    last_update: SensorUpdate | None = None
+
+    def _cb(update: SensorUpdate) -> None:
+        nonlocal last_update
+        last_update = update
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _cb, MagicMock())
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+
+    payload = make_notify_payload(probe1_f10=680)
+
+    async def start_notify_mock(uuid: UUID, callback: Any) -> None:
+        callback(uuid, bytearray(payload))
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        disconnect=AsyncMock(),
+        # Return empty bytes -> battery sensor must not be updated.
+        read_gatt_char=AsyncMock(return_value=b""),
+        write_gatt_char=AsyncMock(),
+    )
+
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(address=IBT_4WB_ADDRESS, name=IBT_4WB_NAME, details={}, rssi=-60),
+        )
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    assert last_update is not None
+    # Temperature probe 1 should be present; battery must NOT be present.
+    assert DeviceKey("temperature_probe_1", None) in last_update.entity_values
+    assert DeviceKey("battery", None) not in last_update.entity_values

--- a/tests/test_ibt_4wb.py
+++ b/tests/test_ibt_4wb.py
@@ -76,11 +76,11 @@ def make_notify_payload(
     Each argument is the temperature in Fahrenheit * 10 (signed int16), or
     None to encode the no-probe sentinel (0x7FFE).
     """
-    NO_PROBE = IBT_4WB_NO_PROBE  # 0x7FFE
+    no_probe = IBT_4WB_NO_PROBE  # 0x7FFE
 
     def encode(val: int | None) -> bytes:
         if val is None:
-            return struct.pack("<H", NO_PROBE)
+            return struct.pack("<H", no_probe)
         return struct.pack("<h", val)
 
     return (
@@ -199,10 +199,10 @@ def test_ibt_4wb_notify_all_probes_active() -> None:
     parser.update(service_info)
 
     payload = make_notify_payload(
-        probe1_f10=680,   # 20.0 °C
-        probe2_f10=750,   # 23.9 °C
+        probe1_f10=680,  # 20.0 °C
+        probe2_f10=750,  # 23.9 °C
         probe3_f10=2120,  # 100.0 °C
-        probe4_f10=320,   # 0.0 °C
+        probe4_f10=320,  # 0.0 °C
     )
     parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001
 
@@ -668,9 +668,9 @@ async def test_calibration_probe1_minus_0_1c() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {1: -0.1})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[0] == 0x09          # calibration command
-    assert cmd[1] == 0x01          # probe 1 bitmask
-    assert cmd[2] == 0xFF          # -1 as unsigned byte
+    assert cmd[0] == 0x09  # calibration command
+    assert cmd[1] == 0x01  # probe 1 bitmask
+    assert cmd[2] == 0xFF  # -1 as unsigned byte
     assert cmd[3] == cmd[4] == cmd[5] == 0x00
 
 
@@ -683,8 +683,8 @@ async def test_calibration_probe2_plus_0_1c() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {2: 0.1})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[1] == 0x02          # probe 2 bitmask
-    assert cmd[3] == 0x01          # +1
+    assert cmd[1] == 0x02  # probe 2 bitmask
+    assert cmd[3] == 0x01  # +1
 
 
 @pytest.mark.asyncio
@@ -696,8 +696,8 @@ async def test_calibration_probe4_plus_1c() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {4: 1.0})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[1] == 0x08          # probe 4 bitmask
-    assert cmd[5] == 0x12          # +18
+    assert cmd[1] == 0x08  # probe 4 bitmask
+    assert cmd[5] == 0x12  # +18
 
 
 @pytest.mark.asyncio
@@ -709,7 +709,7 @@ async def test_calibration_probe4_minus_1c() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {4: -1.0})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[5] == 0xEE          # -18 as unsigned byte
+    assert cmd[5] == 0xEE  # -18 as unsigned byte
 
 
 @pytest.mark.asyncio
@@ -721,8 +721,8 @@ async def test_calibration_probe3_minus_0_2c() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {3: -0.2})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[1] == 0x04          # probe 3 bitmask
-    assert cmd[4] == 0xFD          # -3 as unsigned byte
+    assert cmd[1] == 0x04  # probe 3 bitmask
+    assert cmd[4] == 0xFD  # -3 as unsigned byte
 
 
 @pytest.mark.asyncio
@@ -734,7 +734,7 @@ async def test_calibration_multi_probe() -> None:
         await parser.async_ibt_4wb_set_calibration(_ble_device(), {1: 0.0, 3: 0.0})
 
     cmd = mock_client.write_gatt_char.call_args_list[0].args[1]
-    assert cmd[1] == 0x05          # 0x01 | 0x04
+    assert cmd[1] == 0x05  # 0x01 | 0x04
 
 
 def test_calibration_invalid_probe_raises() -> None:

--- a/tests/test_ibt_4wb.py
+++ b/tests/test_ibt_4wb.py
@@ -835,3 +835,13 @@ async def test_ibt_4wb_battery_read_empty_skips_sensor() -> None:
     # Temperature probe 1 should be present; battery must NOT be present.
     assert DeviceKey("temperature_probe_1", None) in last_update.entity_values
     assert DeviceKey("battery", None) not in last_update.entity_values
+
+
+def test_update_ibt_4wb_notify_no_callback_is_silent() -> None:
+    """_update_ibt_4wb_notify with no update_callback must not raise."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, None, None)
+    service_info = make_ibt_4wb_service_info()
+    parser.update(service_info)
+    payload = make_notify_payload(probe1_f10=680)
+    # Must complete silently even though update_callback is None.
+    parser._notify_callback(MagicMock(), bytearray(payload))  # noqa: SLF001

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,6 +28,7 @@ from inkbird_ble import Model as PublicModel
 from inkbird_ble.parser import (
     BBQ_MODELS,
     GATT_POLL_MODELS,
+    IBT_4WB_DATA_LENGTH,
     IHT_2PB_NOTIFY_UUID,
     IHT_2PB_WRITE_UUID,
     MAX_PLAUSIBLE_BATTERY_PERCENTAGE,
@@ -4494,6 +4495,52 @@ def test_adv_battery_boundary_covers_every_battery_reporting_model() -> None:
     assert set(_ADV_BATTERY_BOUNDARY_CASES) == _BATTERY_REPORTING_SENSOR_MODELS
 
 
+@pytest.mark.asyncio
+async def test_notify_ibt_4wb_wrong_length_ignored() -> None:
+    """Notifications that are not exactly IBT_4WB_DATA_LENGTH bytes are dropped."""
+    updates: list[SensorUpdate] = []
+
+    def _update_callback(update: SensorUpdate) -> None:
+        updates.append(update)
+
+    parser = INKBIRDBluetoothDeviceData(Model.IBT_4WB, {}, _update_callback, None)
+
+    async def start_notify_mock(
+        uuid: UUID, callback: Callable[[UUID, bytes], None]
+    ) -> None:
+        callback(uuid, b"\x00" * (IBT_4WB_DATA_LENGTH - 1))  # too short
+        callback(uuid, b"\x00" * (IBT_4WB_DATA_LENGTH + 1))  # too long
+        callback(uuid, b"")  # empty
+
+    mock_client = MagicMock(
+        start_notify=start_notify_mock,
+        read_gatt_char=AsyncMock(return_value=b"\x64"),
+        write_gatt_char=AsyncMock(),
+        disconnect=AsyncMock(),
+    )
+    service_info = make_bluetooth_service_info(
+        name="Inkbird@IBT-24SPH",
+        manufacturer_data={},
+        service_uuids=["0000ff00-0000-1000-8000-00805f9b34fb"],
+        address="40:79:12:1A:B4:56",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        await parser.async_start(
+            service_info,
+            BLEDevice(
+                address="40:79:12:1A:B4:56", name="Inkbird@IBT-24SPH", details={}
+            ),
+        )
+        await asyncio.sleep(0)
+        await parser.async_stop()
+
+    # Wrong-length packets must not produce any temperature update.
+    assert updates == []
+
+
 # Notify boundary net — extends the ADV boundary-net pattern
 # (#213/#214/#216) to ``NOTIFY_MODELS``. Each notify model must declare at
 # least one named corrupt-input test, so a future notify protocol added to
@@ -4511,6 +4558,7 @@ _NOTIFY_CORRUPT_INPUT_TESTS: dict[Model, tuple[str, ...]] = {
         "test_notify_iam_t1_corrupt_pressure_dropped",
     ),
     Model.IHT_2PB: ("test_notify_iht_2pb_skips_invalid_packets",),
+    Model.IBT_4WB: ("test_notify_ibt_4wb_wrong_length_ignored",),
 }
 
 


### PR DESCRIPTION
Add support for the INKBIRD IBT-4WB 4-probe Bluetooth BBQ thermometer

The IBT-4WB (sold as IBT-24SPH) uses an active BLE connection rather than passive advertisement data, so this adds the necessary infrastructure alongside the existing passive-polling devices.

What's new:

- Device detection — recognises the Inkbird@IBT- name prefix in advertisement data
- 4-probe temperature sensing — decodes the 10-byte FF01 notification payload (temperatures encoded as Fahrenheit × 10, signed int16 LE)
- Unplugged probe handling — sentinel value 0x7FFE is published as None so the entity shows as unavailable rather than retaining a stale reading
- Battery — reads the standard BLE battery characteristic (0x2A19) before subscribing to notifications
- Persistent connection with keepalive — the device drops the link without periodic writes; a background task sends a state-sync command to FF02 every 3 seconds to maintain the connection
- Write commands — public async methods for temperature display unit (°C/°F), sound enable/disable, screen brightness (0–100), and per-probe calibration offset (±5 °C in 0.1 °C steps); write commands reuse the active keepalive connection to avoid BlueZ InProgress errors
- Tests — full coverage of notify parsing, no-probe sentinel, keepalive lifecycle, write commands, and edge cases (empty battery read, stopped callback guard, unknown device type guard)