### PR TITLE
fix(parser): drop multi entry guard when raw is available

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -555,10 +555,13 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         changed_manufacturer_data = self.changed_manufacturer_data(
             service_info, excludes
         )
-        if not changed_manufacturer_data or len(changed_manufacturer_data) > 1:
-            # If len(changed_manufacturer_data) > 1 it means we switched
-            # ble adapters so we do not know which data is the latest
-            # and we need to wait for the next update.
+        if not changed_manufacturer_data:
+            return
+        if service_info.raw is None and len(changed_manufacturer_data) > 1:
+            # Without raw advertisement bytes, multiple changed entries are
+            # ambiguous (missed packets / new source) so we wait for the
+            # next update. When raw is available, changed_manufacturer_data
+            # reflects only the current packet, so trust the last entry.
             return
         last_id = list(changed_manufacturer_data)[-1]
         data = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -581,6 +581,37 @@ def test_unknown_tps():
     )
 
 
+def test_tps_multi_entry_dict_with_raw() -> None:
+    # Two FF AD segments in a single raw advertisement are legal per the
+    # BLE spec. The last one is the most recent reading; previously the
+    # parser bailed on len>1, leaving battery and temperature unset.
+    parser = INKBIRDBluetoothDeviceData()
+    service_info = make_bluetooth_service_info(
+        name="tps",
+        manufacturer_data={
+            2200: b"\x00\x00\x00\x07\xbc\x00\x08",
+            2240: b"\x00\x00\x00&q\x00\x08",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:22:08:15:00:BB",
+        rssi=-59,
+        service_data={},
+        source="98:3D:AE:4F:E9:FA",
+        raw=b"\x02\x01\x06\x03\x02\xf0\xff"
+        b"\x0a\xff\x98\x08\x00\x00\x00\x07\xbc\x00\x08"
+        b"\x0a\xff\xc0\x08\x00\x00\x00&q\x00\x08",
+    )
+    result = parser.update(service_info)
+    assert parser.device_type == Model.IBS_TH2
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 22.4
+    )
+    assert (
+        result.entity_values[DeviceKey(key="battery", device_id=None)].native_value == 0
+    )
+
+
 def test_ibbq_4():
     parser = INKBIRDBluetoothDeviceData()
     service_info = make_bluetooth_service_info(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -612,6 +612,43 @@ def test_tps_multi_entry_dict_with_raw() -> None:
     )
 
 
+def test_tps_multi_entry_dict_without_raw_bails() -> None:
+    # Without raw, multiple newly changed entries are ambiguous (could be
+    # missed packets, a fresh source, etc.) so the parser waits for the
+    # next update rather than guessing.
+    parser = INKBIRDBluetoothDeviceData()
+    first = make_bluetooth_service_info(
+        name="tps",
+        manufacturer_data={2200: b"\x00\x00\x00\x07\xbc\x00\x08"},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:22:08:15:00:BB",
+        rssi=-59,
+        service_data={},
+        source="98:3D:AE:4F:E9:FA",
+    )
+    parser.update(first)
+    second = make_bluetooth_service_info(
+        name="tps",
+        manufacturer_data={
+            2200: b"\x00\x00\x00\x07\xbc\x00\x08",
+            2210: b"\x00\x00\x00\xdf\xb9\x00\x08",
+            2240: b"\x00\x00\x00&q\x00\x08",
+        },
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:22:08:15:00:BB",
+        rssi=-59,
+        service_data={},
+        source="98:3D:AE:4F:E9:FA",
+    )
+    result = parser.update(second)
+    # Temperature stays at the value from the first parse; no new reading
+    # was committed because the diff was ambiguous.
+    assert (
+        result.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 22.0
+    )
+
+
 def test_ibbq_4():
     parser = INKBIRDBluetoothDeviceData()
     service_info = make_bluetooth_service_info(


### PR DESCRIPTION
changed_manufacturer_data already reflects only the current packet when raw is set, so bailing on multiple entries can leave valid readings unparsed; the guard is kept for the no raw fallback path.