### PR TITLE
fix(parser): base poll_needed recency on the latest service_info

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -579,10 +579,16 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         """
         This is called every time we get a service_info for a device or if
         called manually.
+
+        The recency check uses ``service_info.time`` rather than
+        ``self._last_full_update`` so a healthy device whose readings
+        have not changed (and whose repeat advertisements are therefore
+        deduplicated before the parser runs) does not get marked as
+        needing a connectable poll.
         """
         poll_needed = self._supports_polling and (
             not self._last_full_update
-            or (monotonic_time_coarse() - self._last_full_update) > MIN_POLL_INTERVAL
+            or (monotonic_time_coarse() - service_info.time) > MIN_POLL_INTERVAL
         )
         _LOGGER.debug("Poll needed for INKBIRD device %s: %s", self.name, poll_needed)
         return poll_needed

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3079,3 +3079,44 @@ def test_iam_t2_detection_without_name() -> None:
         ].native_value
         == 595
     )
+
+
+def test_poll_needed_recency_uses_service_info_time() -> None:
+    """A stale service_info forces a poll even if the parser updated recently."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBS_TH)
+    service_info = make_bluetooth_service_info(
+        name="sps",
+        manufacturer_data={2096: b"\x0f\x12\x00Z\xc7W\x06"},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    parser.update(service_info)
+    assert parser.poll_needed(service_info, None) is False
+
+    fresh = make_bluetooth_service_info(
+        name="sps",
+        manufacturer_data={2096: b"\x0f\x12\x00Z\xc7W\x06"},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    stale = BluetoothServiceInfoBleak(
+        name=fresh.name,
+        manufacturer_data=fresh.manufacturer_data,
+        service_uuids=fresh.service_uuids,
+        address=fresh.address,
+        rssi=fresh.rssi,
+        service_data=fresh.service_data,
+        source=fresh.source,
+        device=fresh.device,
+        time=monotonic_time_coarse() - 200.0,
+        advertisement=None,
+        connectable=True,
+        tx_power=0,
+    )
+    assert parser.poll_needed(stale, None) is True


### PR DESCRIPTION
## Summary

When the inkbird readings are stable, the HA bluetooth manager dedupes the repeat scan responses before they reach the parser; the previous `poll_needed` relied on `_last_full_update`, which only refreshes when the parser actually runs, so a healthy device kept getting marked as needing a connectable poll after 180 seconds.

This switches the recency check to `service_info.time` so the coordinator can pass us the timestamp of the latest observed advertisement (including deduped ones) and skip the connect fallback when the device is still being seen.

## Test plan

- Added `test_poll_needed_recency_uses_service_info_time` covering both the fresh and stale cases
- `uv run pytest` (existing failures `test_raw_manufacturer_data` and `test_tps_multi_entry_dict_with_raw` are pre-existing on main)