### PR TITLE
fix(parser): extend MIN_POLL_INTERVAL to 330s for AUTO scan cadence

### DIFF
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -298,7 +298,7 @@ NOTIFY_MODELS = {
 
 MANUFACTURER_DATA_ID_EXCLUDES = {2}
 
-MIN_POLL_INTERVAL = 180.0
+MIN_POLL_INTERVAL = 330.0
 
 
 async def async_connect_action(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3230,7 +3230,7 @@ def test_poll_needed_recency_uses_service_info_time() -> None:
         service_data=fresh.service_data,
         source=fresh.source,
         device=fresh.device,
-        time=monotonic_time_coarse() - 200.0,
+        time=monotonic_time_coarse() - 400.0,
         advertisement=None,
         connectable=True,
         tx_power=0,


### PR DESCRIPTION
## Summary

HA's AUTO mode scanners only promise an active scan window every 300 seconds by default, so the previous 180 second `MIN_POLL_INTERVAL` would fire the connectable poll before the next scheduled active scan; bumping the threshold to 330 seconds (300 plus a 30 second cushion) keeps the fallback honest and avoids the unnecessary connect.

## Test plan

- Updated `test_poll_needed_recency_uses_service_info_time` so the stale service_info is 400 seconds old to exercise the new threshold
- `uv run pytest` (the existing `test_raw_manufacturer_data` and `test_tps_multi_entry_dict_with_raw` failures are pre-existing on main)