### PR TITLE
Add ITH-11-B history helpers

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -132,6 +132,38 @@ elif data.poll_needed(service_info, last_poll=None):
     await data.async_poll(ble_device)
 ```
 
+### ITH-11-B offline history helpers
+
+The `ITH-11-B` broadcasts its current temperature, humidity and battery level
+in advertisements. Some devices also expose offline history through a separate
+GATT command sequence used by the official app. `inkbird-ble` does not manage
+that long-running transfer, but it provides ITH-11-B-specific helpers for the
+parts that are useful to downstream integrations:
+
+```python
+from inkbird_ble import (
+    build_ith_11_b_history_clock_command,
+    decode_ith_11_b_history_records,
+    parse_ith_11_b_history_interval,
+)
+
+# Write this payload to fff7 before requesting history.
+clock_payload = build_ith_11_b_history_clock_command()
+
+# Read fff5 to discover the logging interval, when available.
+interval_seconds = parse_ith_11_b_history_interval(config_bytes)
+
+# Pass all fff6 notification payloads produced by the fff4 command 0x01.
+records = decode_ith_11_b_history_records(history_payloads)
+for record in records:
+    print(record.temperature, record.humidity)
+```
+
+Observed ITH-11-B units use `fff6` for notifications, `fff7` for the clock
+write, and `fff4` commands `0x02`, `0x01`, `0x04` for the history sync flow.
+BLE may split the `0x01` response at arbitrary notification boundaries, so pass
+every payload in order to `decode_ith_11_b_history_records()`.
+
 ## Building a `BluetoothServiceInfoBleak` outside Home Assistant
 
 When you are not running inside Home Assistant you can construct the

--- a/src/inkbird_ble/__init__.py
+++ b/src/inkbird_ble/__init__.py
@@ -12,7 +12,14 @@ from sensor_state_data import (
     Units,
 )
 
-from .parser import INKBIRDBluetoothDeviceData, Model
+from .parser import (
+    INKBIRDBluetoothDeviceData,
+    ITH11BHistoryRecord,
+    Model,
+    build_ith_11_b_history_clock_command,
+    decode_ith_11_b_history_records,
+    parse_ith_11_b_history_interval,
+)
 
 __version__ = "1.5.2"
 
@@ -20,10 +27,14 @@ __all__ = [
     "DeviceClass",
     "DeviceKey",
     "INKBIRDBluetoothDeviceData",
+    "ITH11BHistoryRecord",
     "Model",
     "SensorDescription",
     "SensorDeviceInfo",
     "SensorUpdate",
     "SensorValue",
     "Units",
+    "build_ith_11_b_history_clock_command",
+    "decode_ith_11_b_history_records",
+    "parse_ith_11_b_history_interval",
 ]

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 import struct
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum, StrEnum, auto
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -87,12 +88,38 @@ class ModelInfo:
     supports_polling: bool = True
 
 
+@dataclass(frozen=True)
+class ITH11BHistoryRecord:
+    """A decoded ITH-11-B offline history record."""
+
+    temperature: float
+    humidity: float
+
+
 INKBIRD_SERVICE_UUID = UUID("0000fff0-0000-1000-8000-00805f9b34fb")
 EIGHTEEN_BYTE_SENSOR_DATA_CHARACTERISTIC_UUID = UUID(
     "0000fff7-0000-1000-8000-00805f9b34fb"
 )
 NINE_BYTE_SENSOR_DATA_CHARACTERISTIC_UUID = UUID("0000fff2-0000-1000-8000-00805f9b34fb")
 IAM_T1_CHARACTERISTIC_UUID = UUID("0000fff4-0000-1000-8000-00805f9b34fb")
+
+# ITH-11-B offline history support. Observed ITH-11-B units do not expose the
+# fff8/fff9 history characteristics used by some related hygrometers. The
+# official app instead subscribes to fff6 notifications, writes the host clock
+# with a CRC16/MODBUS checksum to fff7, then writes 0x02, 0x01 and 0x04 to fff4.
+# The 0x01 response carries 4-byte records: signed little-endian temperature in
+# tenths of °C followed by unsigned little-endian humidity in tenths of %.
+ITH_11_B_CONFIG_CHARACTERISTIC_UUID = UUID("0000fff5-0000-1000-8000-00805f9b34fb")
+ITH_11_B_HISTORY_COMMAND_CHARACTERISTIC_UUID = UUID(
+    "0000fff4-0000-1000-8000-00805f9b34fb"
+)
+ITH_11_B_HISTORY_NOTIFY_CHARACTERISTIC_UUID = UUID(
+    "0000fff6-0000-1000-8000-00805f9b34fb"
+)
+ITH_11_B_CLOCK_CHARACTERISTIC_UUID = UUID("0000fff7-0000-1000-8000-00805f9b34fb")
+ITH_11_B_HISTORY_COMMAND_SEQUENCE = (b"\x02", b"\x01", b"\x04")
+ITH_11_B_HISTORY_RECORD_LENGTH = 4
+ITH_11_B_HISTORY_PACKET_TRAILER_LENGTH = 2
 
 INKBIRD_UNPACK = struct.Struct("<hH").unpack
 
@@ -533,6 +560,99 @@ MAX_PLAUSIBLE_BATTERY_PERCENTAGE = 100
 # bogus reading alongside potentially-corrupt temperature/humidity fields.
 MAX_PLAUSIBLE_CO2_PPM = 40000
 MAX_PLAUSIBLE_PRESSURE_HPA = 1200
+ITH_11_B_MAX_HISTORY_INTERVAL_SECONDS = 86400
+
+
+def crc16_modbus(data: bytes) -> int:
+    """Return the CRC16/MODBUS checksum for ``data``."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 0x0001:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return crc
+
+
+def build_ith_11_b_history_clock_command(now: datetime | None = None) -> bytes:
+    """Build the ITH-11-B fff7 clock command used before history sync.
+
+    The payload layout observed from the official app is
+    ``second, minute, hour, ISO weekday, day, month, year_le, crc16_le``.
+    If ``now`` is omitted, the local wall clock is used. When ``now`` is
+    provided, its wall-clock components are encoded directly.
+    """
+    if now is None:
+        now = datetime.now().astimezone()
+
+    payload = bytes(
+        (
+            now.second,
+            now.minute,
+            now.hour,
+            now.isoweekday(),
+            now.day,
+            now.month,
+            now.year & 0xFF,
+            now.year >> 8,
+        )
+    )
+    return payload + crc16_modbus(payload).to_bytes(2, "little")
+
+
+def parse_ith_11_b_history_interval(config: bytes) -> int | None:
+    """Return the ITH-11-B history interval in seconds from a fff5 config read."""
+    for offset in (5, 7):
+        if offset + 1 >= len(config):
+            continue
+        value = int.from_bytes(config[offset : offset + 2], "little")
+        if 1 <= value <= ITH_11_B_MAX_HISTORY_INTERVAL_SECONDS:
+            return value
+    return None
+
+
+def decode_ith_11_b_history_records(
+    payloads: Iterable[bytes],
+) -> tuple[ITH11BHistoryRecord, ...]:
+    """Decode ITH-11-B fff6 notification payloads from history command 0x01.
+
+    Observed ITH-11-B notifications carry 4-byte records followed by a 2-byte
+    packet trailer. Callers should pass every 0x01 notification payload in
+    order; this helper drops per-packet trailers before walking the records.
+    Decoding stops at the all-zero terminator or at the first physically
+    implausible record.
+    """
+    data = b"".join(_ith_11_b_history_record_payload(payload) for payload in payloads)
+    records: list[ITH11BHistoryRecord] = []
+    for offset in range(0, len(data) - 3, 4):
+        temperature_raw = int.from_bytes(
+            data[offset : offset + 2], "little", signed=True
+        )
+        humidity_raw = int.from_bytes(data[offset + 2 : offset + 4], "little")
+        if temperature_raw == 0 and humidity_raw == 0:
+            break
+
+        temperature = temperature_raw / 10
+        humidity = humidity_raw / 10
+        if (
+            abs(temperature) > MAX_PLAUSIBLE_AMBIENT_TEMPERATURE_CELSIUS
+            or humidity > MAX_PLAUSIBLE_HUMIDITY
+        ):
+            break
+        records.append(ITH11BHistoryRecord(temperature, humidity))
+    return tuple(records)
+
+
+def _ith_11_b_history_record_payload(payload: bytes) -> bytes:
+    if (
+        len(payload) > ITH_11_B_HISTORY_RECORD_LENGTH
+        and len(payload) % ITH_11_B_HISTORY_RECORD_LENGTH
+        == ITH_11_B_HISTORY_PACKET_TRAILER_LENGTH
+    ):
+        return payload[:-ITH_11_B_HISTORY_PACKET_TRAILER_LENGTH]
+    return payload
 
 
 def convert_temperature(temp: float) -> float:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import pathlib
 import sys
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -37,7 +37,11 @@ from inkbird_ble.parser import (
     NOTIFY_MODELS,
     SENSOR_MODELS,
     INKBIRDBluetoothDeviceData,
+    ITH11BHistoryRecord,
     Model,
+    build_ith_11_b_history_clock_command,
+    decode_ith_11_b_history_records,
+    parse_ith_11_b_history_interval,
 )
 
 from . import async_fire_time_changed
@@ -67,6 +71,24 @@ def test_model_is_public_export():
 def test_constructor_accepts_publicly_exported_model():
     parser = PublicData(PublicModel.IBS_TH)
     assert parser.device_type is PublicModel.IBS_TH
+
+
+def test_ith_11_b_history_helpers_are_public_exports() -> None:
+    assert inkbird_ble.ITH11BHistoryRecord is ITH11BHistoryRecord
+    assert (
+        inkbird_ble.build_ith_11_b_history_clock_command
+        is build_ith_11_b_history_clock_command
+    )
+    assert (
+        inkbird_ble.decode_ith_11_b_history_records is decode_ith_11_b_history_records
+    )
+    assert (
+        inkbird_ble.parse_ith_11_b_history_interval is parse_ith_11_b_history_interval
+    )
+    assert "ITH11BHistoryRecord" in inkbird_ble.__all__
+    assert "build_ith_11_b_history_clock_command" in inkbird_ble.__all__
+    assert "decode_ith_11_b_history_records" in inkbird_ble.__all__
+    assert "parse_ith_11_b_history_interval" in inkbird_ble.__all__
 
 
 def make_bluetooth_service_info(  # noqa: PLR0913
@@ -4198,6 +4220,109 @@ async def test_eighteen_byte_poll_short_read_ignored() -> None:
     assert "temperature" not in keys
     assert "humidity" not in keys
     assert "battery" not in keys
+
+
+def test_ith_11_b_history_clock_command_matches_official_app_trace() -> None:
+    """The ITH-11-B history sync writes local wall-clock time + CRC to fff7."""
+    clock = datetime(2026, 6, 25, 21, 56, 3, tzinfo=timezone(timedelta(hours=9)))
+
+    assert build_ith_11_b_history_clock_command(clock) == bytes.fromhex(
+        "033815041906ea07a327"
+    )
+
+
+def test_ith_11_b_history_clock_command_defaults_to_local_time() -> None:
+    """The ITH-11-B clock command defaults to the host wall clock."""
+    clock = datetime(2026, 6, 25, 21, 56, 3, tzinfo=timezone(timedelta(hours=9)))
+    with patch("inkbird_ble.parser.datetime") as datetime_mock:
+        datetime_mock.now.return_value.astimezone.return_value = clock
+
+        assert build_ith_11_b_history_clock_command() == bytes.fromhex(
+            "033815041906ea07a327"
+        )
+
+
+def test_ith_11_b_history_interval_from_fff5_config() -> None:
+    """The ITH-11-B fff5 config read exposes the logging interval."""
+    config = bytes.fromhex("00000000002c010000000058029cff200364000401c8")
+
+    assert parse_ith_11_b_history_interval(config) == 300
+
+
+def test_ith_11_b_history_interval_ignores_short_config() -> None:
+    """A short ITH-11-B fff5 read does not expose a logging interval."""
+    assert parse_ith_11_b_history_interval(b"\x00" * 6) is None
+
+
+def test_ith_11_b_history_interval_ignores_invalid_values() -> None:
+    """Zero is not a valid ITH-11-B logging interval."""
+    assert parse_ith_11_b_history_interval(b"\x00" * 9) is None
+
+
+def test_ith_11_b_history_records_decode_from_command_01_payload() -> None:
+    """ITH-11-B history command 0x01 returns 4-byte temp/humidity records."""
+    payload = bytes.fromhex(
+        "fd006f02fd006f02fd006d02fd006f02fd007502fd007902fd007d0200000000"
+    )
+
+    records = decode_ith_11_b_history_records((payload,))
+
+    assert records == (
+        ITH11BHistoryRecord(25.3, 62.3),
+        ITH11BHistoryRecord(25.3, 62.3),
+        ITH11BHistoryRecord(25.3, 62.1),
+        ITH11BHistoryRecord(25.3, 62.3),
+        ITH11BHistoryRecord(25.3, 62.9),
+        ITH11BHistoryRecord(25.3, 63.3),
+        ITH11BHistoryRecord(25.3, 63.7),
+    )
+
+
+def test_ith_11_b_history_records_join_notification_boundaries() -> None:
+    """BLE notification boundaries can split a 4-byte ITH-11-B history record."""
+    records = decode_ith_11_b_history_records(
+        (
+            bytes.fromhex("fd006f02fd"),
+            bytes.fromhex("006d0200000000"),
+        )
+    )
+
+    assert records == (
+        ITH11BHistoryRecord(25.3, 62.3),
+        ITH11BHistoryRecord(25.3, 62.1),
+    )
+
+
+def test_ith_11_b_history_records_drop_two_byte_packet_trailers() -> None:
+    """ITH-11-B fff6 history packets include a 2-byte packet trailer."""
+    records = decode_ith_11_b_history_records(
+        (
+            bytes.fromhex("e400b103" * 45 + "0100"),
+            bytes.fromhex("e500e303" * 45 + "0200"),
+        )
+    )
+
+    assert len(records) == 90
+    assert records[44] == ITH11BHistoryRecord(22.8, 94.5)
+    assert records[45] == ITH11BHistoryRecord(22.9, 99.5)
+
+
+def test_ith_11_b_history_records_ignore_incomplete_payload() -> None:
+    """Incomplete ITH-11-B history records are ignored."""
+    assert decode_ith_11_b_history_records((bytes.fromhex("fd006f"),)) == ()
+
+
+def test_ith_11_b_history_records_stop_at_implausible_payload() -> None:
+    """A corrupt ITH-11-B history record terminates decoding."""
+    records = decode_ith_11_b_history_records(
+        (
+            bytes.fromhex("fd006f02"),
+            bytes.fromhex("fd00ffff"),
+            bytes.fromhex("fd006d02"),
+        )
+    )
+
+    assert records == (ITH11BHistoryRecord(25.3, 62.3),)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add ITH-11-B-specific offline history helper APIs for the observed fff6/fff7/fff4 sync flow
- expose helpers from the package root and document downstream usage
- cover the official-app clock command trace, fff5 interval parsing, fff6 record decoding, split notification boundaries, and corrupt-record termination

## Scope
This intentionally does not add a long-running BLE transfer manager. The change is limited to ITH-11-B protocol helpers so downstream integrations can manage connection timing and retries themselves.

## Tests
- uv run --with ruff ruff check .
- uv run --with pytest --with pytest-asyncio --with pytest-cov pytest