### PR TITLE
fix(parser): keep IBS-P01B temperature and battery when humidity field is 0xFFFF

### DIFF
--- a/docs/source/supported_devices.md
+++ b/docs/source/supported_devices.md
@@ -6,25 +6,25 @@ member of the `Model` enum (importable from `inkbird_ble`); pass it to
 the parser detects it from the first advertisement (passive devices) or you
 must supply it (notify-only devices).
 
-| Model                   | Family                  | Transport          | Detection                          | Sensors                                                             |
-| ----------------------- | ----------------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------- |
-| `IBS-TH`                | Hygrometer              | advertisement      | local name `sps`                   | temperature, humidity, battery                                      |
-| `IBS-TH2` / `P01B`      | Hygrometer              | advertisement      | local name `tps`                   | temperature, humidity, battery                                      |
-| `IBS-P02B`              | Pool / probe            | advertisement only | local name `ibs-p02b`              | temperature, battery                                                |
-| `ITH-11-B`              | Hygrometer              | advertisement      | local name `ith-11-b`              | temperature, humidity, battery                                      |
-| `ITH-13-B`              | Hygrometer              | advertisement      | local name `ith-13-b`              | temperature, humidity, battery                                      |
-| `ITH-21-B`              | Hygrometer              | advertisement      | local name `ith-21-b`              | temperature, humidity, battery                                      |
-| `IAM-T1`                | Indoor air quality      | GATT notify        | manufacturer-data `AC-6200` prefix | temperature, humidity, CO₂, atmospheric pressure                    |
-| `IAM-T2`                | Indoor air quality      | advertisement      | 17-byte payload + MAC prefix       | temperature, humidity, CO₂                                          |
-| `IHT-2PB`               | 3-probe thermometer     | GATT notify        | local name `Ink@IHT-2PB#…`         | temperature × 3 probes                                              |
-| `INT-11P-B`             | Connected BBQ probe     | GATT poll          | local name `int-11p-b`             | probe temperature, ambient temperature, probe battery, case battery |
-| `INT-11I-B`             | Connected probe         | GATT poll          | local name `int-11i-b`             | temperature, station battery, probe battery                         |
-| `iBBQ-1`                | BBQ probe (1 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 1                                                     |
-| `iBBQ-2`                | BBQ probe (2 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 2                                                     |
-| `iBBQ-4`                | BBQ probe (4 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 4                                                     |
-| `iBBQ-6`                | BBQ probe (6 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 6                                                     |
-| `Generic 18 byte model` | Unknown hygrometer      | advertisement      | 18-byte payload + service UUID     | temperature, humidity, battery                                      |
-| `IDT-34c-B`             | 6-probe BBQ thermometer | GATT notify        | local name `idt-34c-b`             | temperature × 6 probes, battery                                     |
+| Model                   | Family                  | Transport          | Detection                          | Sensors                                                                        |
+| ----------------------- | ----------------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------------------ |
+| `IBS-TH`                | Hygrometer              | advertisement      | local name `sps`                   | temperature, humidity, battery                                                 |
+| `IBS-TH2` / `P01B`      | Hygrometer              | advertisement      | local name `tps`                   | temperature, humidity (IBS-TH2 only; the P01B has no humidity sensor), battery |
+| `IBS-P02B`              | Pool / probe            | advertisement only | local name `ibs-p02b`              | temperature, battery                                                           |
+| `ITH-11-B`              | Hygrometer              | advertisement      | local name `ith-11-b`              | temperature, humidity, battery                                                 |
+| `ITH-13-B`              | Hygrometer              | advertisement      | local name `ith-13-b`              | temperature, humidity, battery                                                 |
+| `ITH-21-B`              | Hygrometer              | advertisement      | local name `ith-21-b`              | temperature, humidity, battery                                                 |
+| `IAM-T1`                | Indoor air quality      | GATT notify        | manufacturer-data `AC-6200` prefix | temperature, humidity, CO₂, atmospheric pressure                               |
+| `IAM-T2`                | Indoor air quality      | advertisement      | 17-byte payload + MAC prefix       | temperature, humidity, CO₂                                                     |
+| `IHT-2PB`               | 3-probe thermometer     | GATT notify        | local name `Ink@IHT-2PB#…`         | temperature × 3 probes                                                         |
+| `INT-11P-B`             | Connected BBQ probe     | GATT poll          | local name `int-11p-b`             | probe temperature, ambient temperature, probe battery, case battery            |
+| `INT-11I-B`             | Connected probe         | GATT poll          | local name `int-11i-b`             | temperature, station battery, probe battery                                    |
+| `iBBQ-1`                | BBQ probe (1 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 1                                                                |
+| `iBBQ-2`                | BBQ probe (2 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 2                                                                |
+| `iBBQ-4`                | BBQ probe (4 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 4                                                                |
+| `iBBQ-6`                | BBQ probe (6 channel)   | advertisement      | name contains `xbbq` / `ibbq`      | temperature × 6                                                                |
+| `Generic 18 byte model` | Unknown hygrometer      | advertisement      | 18-byte payload + service UUID     | temperature, humidity, battery                                                 |
+| `IDT-34c-B`             | 6-probe BBQ thermometer | GATT notify        | local name `idt-34c-b`             | temperature × 6 probes, battery                                                |
 
 ## Transport guide
 

--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -570,6 +570,12 @@ def try_parse_model(value: str | Model | None) -> Model | None:
 # a bogus 6553.5°C reading.
 BBQ_PROBE_NOT_CONNECTED = frozenset((0xFFFF, -1))
 
+# The IBS-P01B advertises under the same ``tps`` name as the IBS-TH2, but it
+# has no humidity sensor. Instead it sends 0x0000 (older firmware) or 0xFFFF
+# (firmware 2.3.0) in the humidity field. Neither value means the packet is
+# corrupt, so they must not trigger the corrupt-packet check below.
+HUMIDITY_SENSOR_NOT_FITTED = frozenset((0, 0xFFFF))
+
 # Inkbird hygrometers occasionally emit a corrupt advertisement where the
 # unsigned humidity field is garbage (e.g. 0xFFFF -> 6553.5%) and the
 # temperature reads 0. Relative humidity cannot exceed 100%, so a reading
@@ -1242,9 +1248,11 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         if TYPE_CHECKING:
             assert self._device_type is not None
         temp, hum = MODEL_INFO[self._device_type].unpacker(temp_hum_bytes)
-        # Only some models report humidity: IBS-TH always, IBS-TH2 when non-zero.
+        # Only some models report humidity: IBS-TH always, IBS-TH2 unless the
+        # humidity field holds one of the "no sensor" values sent by the
+        # IBS-P01B. In that case skip humidity but keep temperature and battery.
         reports_humidity = self._device_type == Model.IBS_TH or (
-            self._device_type == Model.IBS_TH2 and hum != 0
+            self._device_type == Model.IBS_TH2 and hum not in HUMIDITY_SENSOR_NOT_FITTED
         )
         humidity = hum / 100
         if reports_humidity and not self._is_humidity_plausible(humidity):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -683,6 +683,124 @@ def test_tps_multi_entry_dict_without_raw_bails() -> None:
     )
 
 
+_TEMPERATURE_KEY = DeviceKey(key="temperature", device_id=None)
+_BATTERY_KEY = DeviceKey(key="battery", device_id=None)
+_HUMIDITY_KEY = DeviceKey(key="humidity", device_id=None)
+
+# Real IBS-P01B (firmware 2.3.0) advertisements; humidity field is always ff ff.
+_IBS_P01B_FFFF_HUMIDITY_ADVS: list[tuple[int, str, float, int]] = [
+    # (manufacturer id == temperature field, payload, temp C, battery %)
+    (440, "ffff00f4273208", 4.40, 50),
+    (450, "ffff002ded3208", 4.50, 50),
+    (2405, "ffff001a543908", 24.05, 57),
+    (4375, "ffff0024ff3908", 43.75, 57),
+]
+
+
+def _ibs_p01b_service_info(mfr_id: int, payload_hex: str) -> BluetoothServiceInfoBleak:
+    payload = bytes.fromhex(payload_hex)
+    return make_bluetooth_service_info(
+        name="tps",
+        manufacturer_data={mfr_id: payload},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:26:02:27:03:9f",
+        rssi=-34,
+        service_data={},
+        source="esphome-proxy",
+        raw=bytes.fromhex("0201060302f0ff")
+        + b"\x0a\xff"
+        + mfr_id.to_bytes(2, "little")
+        + payload,
+    )
+
+
+@pytest.mark.parametrize(
+    ("mfr_id", "payload_hex", "expected_temp", "expected_battery"),
+    _IBS_P01B_FFFF_HUMIDITY_ADVS,
+)
+def test_ibs_p01b_ffff_humidity_means_no_sensor(
+    mfr_id: int, payload_hex: str, expected_temp: float, expected_battery: int
+) -> None:
+    """An IBS-P01B sending ``ff ff`` humidity has no sensor; it is not a bad packet."""
+    parser = INKBIRDBluetoothDeviceData()
+    result = parser.update(_ibs_p01b_service_info(mfr_id, payload_hex))
+    assert parser.device_type is Model.IBS_TH2
+    assert result.entity_values[_TEMPERATURE_KEY].native_value == expected_temp
+    assert result.entity_values[_BATTERY_KEY].native_value == expected_battery
+    assert _HUMIDITY_KEY not in result.entity_values
+    assert _HUMIDITY_KEY not in result.entity_descriptions
+
+
+def test_ibs_p01b_ffff_humidity_keeps_updating_across_advertisements() -> None:
+    """Successive P01B advertisements each produce a fresh temperature."""
+    parser = INKBIRDBluetoothDeviceData()
+    seen: list[float] = []
+    for mfr_id, payload_hex, expected_temp, _ in _IBS_P01B_FFFF_HUMIDITY_ADVS:
+        result = parser.update(_ibs_p01b_service_info(mfr_id, payload_hex))
+        assert result.entity_values[_TEMPERATURE_KEY].native_value == expected_temp
+        seen.append(result.entity_values[_TEMPERATURE_KEY].native_value)
+    assert seen == [4.40, 4.50, 24.05, 43.75]
+
+
+@pytest.mark.asyncio
+async def test_ibs_p01b_poll_ffff_humidity_is_not_fitted() -> None:
+    """Polling over GATT uses the same decoder, so ``ff ff`` is handled there too."""
+    parser = INKBIRDBluetoothDeviceData(Model.IBS_TH2)
+    service_info = make_bluetooth_service_info(
+        name="tps",
+        manufacturer_data={},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="49:26:02:27:03:9f",
+        rssi=-34,
+        service_data={},
+        source="local",
+    )
+    parser.update(service_info)
+    read_gatt_char_mock = AsyncMock(return_value=b"\xb8\x01\xff\xff\x00\xf4\x27")
+    mock_client = MagicMock(read_gatt_char=read_gatt_char_mock, disconnect=AsyncMock())
+    with patch("inkbird_ble.parser.establish_connection", return_value=mock_client):
+        update = await parser.async_poll(
+            BLEDevice(address="49:26:02:27:03:9f", name="tps", details={})
+        )
+    assert update.entity_values[_TEMPERATURE_KEY].native_value == 4.40
+    assert _HUMIDITY_KEY not in update.entity_values
+    assert _BATTERY_KEY not in update.entity_values
+
+
+def test_ibs_th_ffff_humidity_is_still_corrupt_and_dropped() -> None:
+    """An IBS-TH always has a humidity sensor, so ``ff ff`` is still a bad packet."""
+    parser = INKBIRDBluetoothDeviceData()
+    payload = bytes.fromhex("ffff00f4273208")
+    service_info = make_bluetooth_service_info(
+        name="sps",
+        manufacturer_data={440: payload},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-34,
+        service_data={},
+        source="local",
+        raw=bytes.fromhex("0201060302f0ff")
+        + b"\x0a\xff"
+        + (440).to_bytes(2, "little")
+        + payload,
+    )
+    result = parser.update(service_info)
+    assert parser.device_type is Model.IBS_TH
+    assert set(result.entity_values) == {
+        DeviceKey(key="signal_strength", device_id=None)
+    }
+
+
+def test_ibs_th2_other_impossible_humidity_is_still_dropped() -> None:
+    """Any other impossible humidity on an IBS-TH2 is still a bad packet (#141)."""
+    parser = INKBIRDBluetoothDeviceData()
+    result = parser.update(_ibs_p01b_service_info(440, "008000f4273208"))
+    assert parser.device_type is Model.IBS_TH2
+    assert set(result.entity_values) == {
+        DeviceKey(key="signal_strength", device_id=None)
+    }
+
+
 def test_ibbq_4():
     parser = INKBIRDBluetoothDeviceData()
     service_info = make_bluetooth_service_info(
@@ -4408,7 +4526,9 @@ _ADV_HUMIDITY_BOUNDARY_CASES: dict[Model, tuple[str, int, bytes, slice]] = {
     ),
 }
 
-_HUMIDITY_KEY = DeviceKey(key="humidity", device_id=None)
+# Models where 0xFFFF humidity means "no sensor" rather than a bad packet,
+# so the temperature reading must still come through.
+_HUMIDITY_FFFF_IS_NOT_FITTED: frozenset[Model] = frozenset({Model.IBS_TH2})
 
 
 def _boundary_service_info(
@@ -4452,6 +4572,10 @@ def test_adv_humidity_boundary_invariant(model: Model) -> None:
     )
     assert corrupt.device_type is model
     assert corrupt_result.entity_values.get(_HUMIDITY_KEY) is None
+    if model in _HUMIDITY_FFFF_IS_NOT_FITTED:
+        assert corrupt_result.entity_values.get(_TEMPERATURE_KEY) is not None
+    else:
+        assert corrupt_result.entity_values.get(_TEMPERATURE_KEY) is None
 
 
 def test_adv_humidity_boundary_covers_every_sensor_model() -> None:


### PR DESCRIPTION
## Problem

The IBS-P01B advertises under the same `tps` local name as the IBS-TH2, but it has no humidity sensor.
Instead it fills the humidity field with `0x0000` (older firmware) or `0xFFFF` (firmware 2.3.0).

Since #141, an impossible humidity value is treated as a corrupt packet and the whole reading is
dropped. That is correct for hygrometers, but for a P01B on firmware 2.3.0 it means every advertisement
is discarded: `0xFFFF` parses as 655.35 %, so temperature and battery never come through, and the
device has no working sensors in Home Assistant.

## Fix

Add `HUMIDITY_SENSOR_NOT_FITTED = frozenset((0, 0xFFFF))` and treat those two values on an IBS-TH2 as
"no humidity sensor" rather than a corrupt packet. Humidity is skipped, temperature and battery are
published as normal. This extends the existing `hum != 0` special case, which already handled the
older-firmware P01B.

## Tests

- Parametrised test over advertisements captured from a real P01B (firmware 2.3.0): temperature and
  battery present, no humidity entity.
- Successive advertisements keep producing fresh temperatures.
- GATT poll path with `ff ff` humidity.
- Negative cases: IBS-TH with `ff ff` is still dropped; IBS-TH2 with any other impossible humidity
  is still dropped.
- `test_adv_humidity_boundary_invariant` now also asserts that temperature survives for IBS-TH2 and is
  dropped for every other model.

`pytest`: 138 passed, no uncovered statements. `pre-commit run -a`: clean.

## Docs

`supported_devices.md` notes that the P01B has no humidity sensor.

## Verified on hardware

Backported onto 1.4.4 (the version Home Assistant currently pins) and run against the P01B above in a
live HA instance: temperature and battery now update on every advertisement, no humidity entity is created.